### PR TITLE
Fix codecov reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ python:
  - "3.8"
 
 env:
-  - DJANGO=2.2
-  # - DJANGO=3.0
+  - DJANGO=2.2 CMIS_BINDING=BROWSER
+  - DJANGO=2.2 CMIS_BINDING=WEBSERVICE
+  # - DJANGO=3.0 CMIS_BINDING=BROWSER
+  # - DJANGO=3.0 CMIS_BINDING=WEBSERVICE
 
 install:
   - pip install tox tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ after_script:
 
 after_success:
   - pip install codecov
-  - codecov -e TOXENV,DJANGO
+  - export envname=py${TRAVIS_PYTHON_VERSION/./}-django${DJANGO/./}-$(echo $CMIS_BINDING | tr '[:upper:]' '[:lower:]')
+  - codecov -e TOXENV,DJANGO --file reports/coverage-${envname}.xml
 
 jobs:
   fast_finish: true

--- a/alfresco/docker-compose.yml
+++ b/alfresco/docker-compose.yml
@@ -11,7 +11,7 @@ version: "2"
 services:
     alfresco:
         image: alfresco/alfresco-content-repository-community:6.1.2-ga
-        mem_limit: 1500m
+        mem_limit: 3g
         environment:
             JAVA_OPTS : "
                 -Ddb.driver=org.postgresql.Driver

--- a/drc_cmis/admin.py
+++ b/drc_cmis/admin.py
@@ -26,7 +26,15 @@ class CMISConfigAdmin(SingletonModelAdmin):
                 )
             },
         ),
-        (_("Credentials"), {"fields": ("client_user", "client_password",)}),
+        (
+            _("Credentials"),
+            {
+                "fields": (
+                    "client_user",
+                    "client_password",
+                )
+            },
+        ),
     )
 
     def cmis_enabled(self, obj):

--- a/drc_cmis/browser/client.py
+++ b/drc_cmis/browser/client.py
@@ -286,7 +286,10 @@ class CMISDRCClient(CMISClient, CMISRequest):
             raise DocumentDoesNotExistError(error_string)
 
     def create_document(
-        self, identification: str, data: dict, content: BytesIO = None,
+        self,
+        identification: str,
+        data: dict,
+        content: BytesIO = None,
     ) -> Document:
         """Create a cmis document.
 

--- a/drc_cmis/migrations/0004_auto_20200616_0919.py
+++ b/drc_cmis/migrations/0004_auto_20200616_0919.py
@@ -10,7 +10,10 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RemoveField(model_name="cmisconfig", name="locations",),
+        migrations.RemoveField(
+            model_name="cmisconfig",
+            name="locations",
+        ),
         migrations.AddField(
             model_name="cmisconfig",
             name="base_folder",
@@ -49,5 +52,7 @@ class Migration(migrations.Migration):
                 max_length=200,
             ),
         ),
-        migrations.DeleteModel(name="CMISFolderLocation",),
+        migrations.DeleteModel(
+            name="CMISFolderLocation",
+        ),
     ]

--- a/drc_cmis/migrations/0012_auto_20200821_1512.py
+++ b/drc_cmis/migrations/0012_auto_20200821_1512.py
@@ -12,7 +12,10 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RemoveField(model_name="cmisconfig", name="base_folder_name",),
+        migrations.RemoveField(
+            model_name="cmisconfig",
+            name="base_folder_name",
+        ),
         migrations.AddField(
             model_name="cmisconfig",
             name="other_folder_path",

--- a/drc_cmis/models.py
+++ b/drc_cmis/models.py
@@ -25,7 +25,9 @@ class CMISConfig(SingletonModel):
         "http://domain_name:port_number/alfresco/api/-default-/public/cmis/versions/1.1/browser",
     )
     binding = models.CharField(
-        choices=BINDING_CHOICES, default="BROWSER", max_length=200,
+        choices=BINDING_CHOICES,
+        default="BROWSER",
+        max_length=200,
     )
     time_zone = models.CharField(
         default="UTC",

--- a/drc_cmis/utils/folder.py
+++ b/drc_cmis/utils/folder.py
@@ -8,19 +8,24 @@ PathElement = namedtuple("PathElement", ["folder_name", "object_type"])
 PathElementTemplate = namedtuple("PathElementTemplate", ["folder_name", "required"])
 
 YEAR_PATH_ELEMENT_TEMPLATE = PathElementTemplate(
-    folder_name="{{ year }}", required=False,
+    folder_name="{{ year }}",
+    required=False,
 )
 MONTH_PATH_ELEMENT_TEMPLATE = PathElementTemplate(
-    folder_name="{{ month }}", required=False,
+    folder_name="{{ month }}",
+    required=False,
 )
 DAY_PATH_ELEMENT_TEMPLATE = PathElementTemplate(
-    folder_name="{{ day }}", required=False,
+    folder_name="{{ day }}",
+    required=False,
 )
 ZAAKTYPE_PATH_ELEMENT_TEMPLATE = PathElementTemplate(
-    folder_name="{{ zaaktype }}", required=True,
+    folder_name="{{ zaaktype }}",
+    required=True,
 )
 ZAAK_PATH_ELEMENT_TEMPLATE = PathElementTemplate(
-    folder_name="{{ zaak }}", required=True,
+    folder_name="{{ zaak }}",
+    required=True,
 )
 
 

--- a/drc_cmis/webservice/client.py
+++ b/drc_cmis/webservice/client.py
@@ -309,7 +309,8 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
         )
 
         soap_response = self.request(
-            "ObjectService", soap_envelope=soap_envelope.toxml(),
+            "ObjectService",
+            soap_envelope=soap_envelope.toxml(),
         )
 
         # Creating the document only returns its ID
@@ -390,7 +391,8 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
         )
 
         soap_response = self.request(
-            "ObjectService", soap_envelope=soap_envelope.toxml(),
+            "ObjectService",
+            soap_envelope=soap_envelope.toxml(),
         )
 
         xml_response = extract_xml_from_soap(soap_response)

--- a/drc_cmis/webservice/drc_document.py
+++ b/drc_cmis/webservice/drc_document.py
@@ -336,7 +336,8 @@ class Document(CMISContentObject):
         )
 
         soap_response = self.request(
-            "ObjectService", soap_envelope=soap_envelope.toxml(),
+            "ObjectService",
+            soap_envelope=soap_envelope.toxml(),
         )
 
         xml_response = extract_xml_from_soap(soap_response)
@@ -397,7 +398,8 @@ class Document(CMISContentObject):
             )
 
             self.request(
-                "VersioningService", soap_envelope=soap_envelope.toxml(),
+                "VersioningService",
+                soap_envelope=soap_envelope.toxml(),
             )
             refreshed_document = self.get_latest_version()
             return refreshed_document.delete_object()

--- a/drc_cmis/webservice/request.py
+++ b/drc_cmis/webservice/request.py
@@ -146,31 +146,52 @@ class SOAPCMISRequest:
             error = soap_response.text
             if soap_response.status_code == 401:
                 raise CmisPermissionDeniedException(
-                    status=soap_response.status_code, url=url, message=error, code=401,
+                    status=soap_response.status_code,
+                    url=url,
+                    message=error,
+                    code=401,
                 )
             elif soap_response.status_code == 400:
                 raise CmisInvalidArgumentException(
-                    status=soap_response.status_code, url=url, message=error, code=400,
+                    status=soap_response.status_code,
+                    url=url,
+                    message=error,
+                    code=400,
                 )
             elif soap_response.status_code == 404:
                 raise CmisObjectNotFoundException(
-                    status=soap_response.status_code, url=url, message=error, code=404,
+                    status=soap_response.status_code,
+                    url=url,
+                    message=error,
+                    code=404,
                 )
             elif soap_response.status_code == 403:
                 raise CmisPermissionDeniedException(
-                    status=soap_response.status_code, url=url, message=error, code=403,
+                    status=soap_response.status_code,
+                    url=url,
+                    message=error,
+                    code=403,
                 )
             elif soap_response.status_code == 405:
                 raise CmisNotSupportedException(
-                    status=soap_response.status_code, url=url, message=error, code=405,
+                    status=soap_response.status_code,
+                    url=url,
+                    message=error,
+                    code=405,
                 )
             elif soap_response.status_code == 409:
                 raise CmisUpdateConflictException(
-                    status=soap_response.status_code, url=url, message=error, code=409,
+                    status=soap_response.status_code,
+                    url=url,
+                    message=error,
+                    code=409,
                 )
             elif soap_response.status_code == 500:
                 raise CmisRuntimeException(
-                    status=soap_response.status_code, url=url, message=error, code=500,
+                    status=soap_response.status_code,
+                    url=url,
+                    message=error,
+                    code=500,
                 )
             else:
                 raise CmisBaseException(

--- a/drc_cmis/webservice/utils.py
+++ b/drc_cmis/webservice/utils.py
@@ -217,7 +217,8 @@ def make_soap_envelope(
     # Username token
     username_token = xml_doc.createElement("wsse:UsernameToken")
     username_token.setAttribute(
-        "wsu:Id", f"UsernameToken-{security_header_id}",
+        "wsu:Id",
+        f"UsernameToken-{security_header_id}",
     )
     username_tag = xml_doc.createElement("wsse:Username")
     username_text = xml_doc.createTextNode(auth[0])
@@ -241,7 +242,8 @@ def make_soap_envelope(
     # Time stamp
     time_stamp_tag = xml_doc.createElement("wsu:Timestamp")
     time_stamp_tag.setAttribute(
-        "wsu:Id", f"TS-{security_header_id}",
+        "wsu:Id",
+        f"TS-{security_header_id}",
     )
 
     created_tag = xml_doc.createElement("wsu:Created")

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ tests =
     tox
     isort
     black
-    factory-boy >= 3.0.0 
+    factory-boy >= 3.0.0
     psycopg2
     responses
     freezegun

--- a/test_app/app/management/commands/validate_dms.py
+++ b/test_app/app/management/commands/validate_dms.py
@@ -103,12 +103,15 @@ def get_folder(client):
 
 def create_folder(client):
     client.create_folder(
-        f"TestFolder-{get_random_string()}", client.get_or_create_other_folder().objectId
+        f"TestFolder-{get_random_string()}",
+        client.get_or_create_other_folder().objectId,
     )
 
 
 def get_or_create_folder(client):
-    client.get_or_create_folder(f"TestFolder-{get_random_string()}", client.get_or_create_other_folder())
+    client.get_or_create_folder(
+        f"TestFolder-{get_random_string()}", client.get_or_create_other_folder()
+    )
 
 
 def create_zaaktype_folder(client):
@@ -160,13 +163,16 @@ def create_zaak_folder(client):
             },
         }
     client.create_folder(
-        f"TestZaakFolder-{get_random_string()}", client.get_or_create_other_folder().objectId, properties
+        f"TestZaakFolder-{get_random_string()}",
+        client.get_or_create_other_folder().objectId,
+        properties,
     )
 
 
 def delete_folder(client):
     folder = client.create_folder(
-        f"TestFolder-{get_random_string()}", client.get_or_create_other_folder().objectId
+        f"TestFolder-{get_random_string()}",
+        client.get_or_create_other_folder().objectId,
     )
     folder.delete_tree()
 
@@ -352,7 +358,9 @@ def move_document(client):
     document = client.create_document(
         identification=uuid.uuid4(), data=data, content=content
     )
-    folder = client.create_folder("TestFolderForMove", client.get_or_create_other_folder().objectId)
+    folder = client.create_folder(
+        "TestFolderForMove", client.get_or_create_other_folder().objectId
+    )
     document.move_object(folder)
 
 

--- a/test_app/settings.py
+++ b/test_app/settings.py
@@ -54,7 +54,9 @@ TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "APP_DIRS": True,
-        "DIRS": [os.path.join(PROJECT_DIR, "templates"),],
+        "DIRS": [
+            os.path.join(PROJECT_DIR, "templates"),
+        ],
         "OPTIONS": {
             "debug": DEBUG,
             "context_processors": [

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -202,13 +202,19 @@ class CMISClientFolderTests(DMSMixin, TestCase):
             FolderDoesNotExistError, self.cmis_client.get_folder, base_folder.objectId
         )
         self.assertRaises(
-            FolderDoesNotExistError, self.cmis_client.get_folder, folder1.objectId,
+            FolderDoesNotExistError,
+            self.cmis_client.get_folder,
+            folder1.objectId,
         )
         self.assertRaises(
-            FolderDoesNotExistError, self.cmis_client.get_folder, folder2.objectId,
+            FolderDoesNotExistError,
+            self.cmis_client.get_folder,
+            folder2.objectId,
         )
         self.assertRaises(
-            FolderDoesNotExistError, self.cmis_client.get_folder, folder3.objectId,
+            FolderDoesNotExistError,
+            self.cmis_client.get_folder,
+            folder3.objectId,
         )
 
     def test_get_vendor(self):
@@ -284,7 +290,8 @@ class CMISClientContentObjectsTests(DMSMixin, TestCase):
             gebruiksrechten.informatieobject, properties["informatieobject"]
         )
         self.assertEqual(
-            gebruiksrechten.startdatum, properties["startdatum"],
+            gebruiksrechten.startdatum,
+            properties["startdatum"],
         )
         self.assertEqual(
             gebruiksrechten.omschrijving_voorwaarden,
@@ -517,7 +524,9 @@ class CMISClientOIOTests(DMSMixin, TestCase):
         self.cmis_client.create_oio(oio)
 
         # Test the new folder structure
-        zaaktype_folders = self.cmis_client.query(return_type_name="zaaktypefolder",)
+        zaaktype_folders = self.cmis_client.query(
+            return_type_name="zaaktypefolder",
+        )
         self.assertEqual(len(zaaktype_folders), 1)
         self.assertEqual(zaaktype_folders[0].name, "zaaktype-Melding Openbare Ruimte-1")
 
@@ -593,7 +602,9 @@ class CMISClientOIOTests(DMSMixin, TestCase):
         self.cmis_client.create_oio(data=oio2)
 
         # Test that the second folder structure
-        zaaktype_folders = self.cmis_client.query(return_type_name="zaaktypefolder",)
+        zaaktype_folders = self.cmis_client.query(
+            return_type_name="zaaktypefolder",
+        )
         self.assertEqual(len(zaaktype_folders), 2)
         children_folders_names = [folder.name for folder in zaaktype_folders]
         self.assertIn("zaaktype-Melding Openbare Ruimte-1", children_folders_names)
@@ -676,7 +687,9 @@ class CMISClientOIOTests(DMSMixin, TestCase):
         content = io.BytesIO(b"some file content")
 
         document = self.cmis_client.create_document(
-            identification=identification, data=properties, content=content,
+            identification=identification,
+            data=properties,
+            content=content,
         )
 
         # Test that the document is in the temporary folder
@@ -695,7 +708,9 @@ class CMISClientOIOTests(DMSMixin, TestCase):
         self.cmis_client.create_oio(oio)
 
         # Test the new folder structure
-        zaaktype_folders = self.cmis_client.query(return_type_name="zaaktypefolder",)
+        zaaktype_folders = self.cmis_client.query(
+            return_type_name="zaaktypefolder",
+        )
         self.assertEqual(len(zaaktype_folders), 1)
 
         self.assertEqual(zaaktype_folders[0].name, "zaaktype-Melding Openbare Ruimte-1")
@@ -775,7 +790,9 @@ class CMISClientOIOTests(DMSMixin, TestCase):
         self.cmis_client.create_oio(data=oio2)
 
         # Test the second folder structure
-        zaaktype_folders = self.cmis_client.query(return_type_name="zaaktypefolder",)
+        zaaktype_folders = self.cmis_client.query(
+            return_type_name="zaaktypefolder",
+        )
         self.assertEqual(len(zaaktype_folders), 2)
         children_folders_names = [folder.name for folder in zaaktype_folders]
         self.assertIn("zaaktype-Melding Openbare Ruimte-1", children_folders_names)
@@ -988,7 +1005,9 @@ class CMISClientOIOTests(DMSMixin, TestCase):
         content = io.BytesIO(b"some file content")
 
         document = self.cmis_client.create_document(
-            identification=identification, data=properties, content=content,
+            identification=identification,
+            data=properties,
+            content=content,
         )
 
         # Get the temporary folder
@@ -1035,7 +1054,9 @@ class CMISClientOIOTests(DMSMixin, TestCase):
         content = io.BytesIO(b"some file content")
 
         document = self.cmis_client.create_document(
-            identification=identification, data=properties, content=content,
+            identification=identification,
+            data=properties,
+            content=content,
         )
 
         # Creating the oio leaves the document in the temporary folder
@@ -1056,7 +1077,9 @@ class CMISClientOIOTests(DMSMixin, TestCase):
         oio_zaak = self.cmis_client.create_oio(oio_zaak_data)
 
         # Get new folder structure
-        zaaktype_folders = self.cmis_client.query(return_type_name="zaaktypefolder",)
+        zaaktype_folders = self.cmis_client.query(
+            return_type_name="zaaktypefolder",
+        )
         self.assertEqual(len(zaaktype_folders), 1)
 
         self.assertEqual(zaaktype_folders[0].name, "zaaktype-Melding Openbare Ruimte-1")
@@ -1115,7 +1138,9 @@ class CMISClientOIOTests(DMSMixin, TestCase):
         content = io.BytesIO(b"some file content")
 
         document = self.cmis_client.create_document(
-            identification=identification, data=properties, content=content,
+            identification=identification,
+            data=properties,
+            content=content,
         )
 
         # Link document to zaak
@@ -1232,7 +1257,9 @@ class CMISClientGebruiksrechtenTests(DMSMixin, TestCase):
         content = io.BytesIO(b"some file content")
 
         document = self.cmis_client.create_document(
-            identification=identification, data=properties, content=content,
+            identification=identification,
+            data=properties,
+            content=content,
         )
 
         # Create gebruiksrechten
@@ -1296,7 +1323,9 @@ class CMISClientGebruiksrechtenTests(DMSMixin, TestCase):
         content = io.BytesIO(b"some file content")
 
         document = self.cmis_client.create_document(
-            identification=identification, data=properties, content=content,
+            identification=identification,
+            data=properties,
+            content=content,
         )
 
         # Create gebruiksrechten (also in temporary folder)
@@ -1325,7 +1354,8 @@ class CMISClientGebruiksrechtenTests(DMSMixin, TestCase):
 
         gebruiksrechten_parent = gebruiksrechten.get_parent_folders()[0]
         self.assertNotEqual(
-            related_data_folder.objectId, gebruiksrechten_parent.objectId,
+            related_data_folder.objectId,
+            gebruiksrechten_parent.objectId,
         )
 
         # Check that the parent folder of the Gebruiksrechten is in the zaak folder
@@ -1364,7 +1394,9 @@ class CMISClientGebruiksrechtenTests(DMSMixin, TestCase):
         content = io.BytesIO(b"some file content")
 
         document = self.cmis_client.create_document(
-            identification=identification, data=properties, content=content,
+            identification=identification,
+            data=properties,
+            content=content,
         )
 
         # Creating the oio moves the document to the zaak folder
@@ -1486,14 +1518,17 @@ class CMISClientDocumentTests(DMSMixin, TestCase):
         content = io.BytesIO(b"some file content")
 
         document = self.cmis_client.create_document(
-            identification=identification, data=properties, content=content,
+            identification=identification,
+            data=properties,
+            content=content,
         )
 
         self.assertIsNotNone(document.uuid)
         self.assertEqual(document.identificatie, identification)
         self.assertEqual(document.bronorganisatie, "159351741")
         self.assertEqual(
-            document.creatiedatum, properties["creatiedatum"],
+            document.creatiedatum,
+            properties["creatiedatum"],
         )
         self.assertEqual(document.titel, "detailed summary")
         self.assertEqual(document.auteur, "test_auteur")
@@ -1528,10 +1563,12 @@ class CMISClientDocumentTests(DMSMixin, TestCase):
 
         self.assertIsNotNone(document.uuid)
         self.assertEqual(
-            document.creatiedatum, properties["creatiedatum"],
+            document.creatiedatum,
+            properties["creatiedatum"],
         )
         self.assertEqual(
-            document.begin_registratie, properties["begin_registratie"],
+            document.begin_registratie,
+            properties["begin_registratie"],
         )
 
     def test_create_existing_document_raises_error(self):
@@ -1693,7 +1730,9 @@ class CMISClientDocumentTests(DMSMixin, TestCase):
         content = io.BytesIO(b"Content before update")
 
         document = self.cmis_client.create_document(
-            identification=identification, data=properties, content=content,
+            identification=identification,
+            data=properties,
+            content=content,
         )
 
         new_properties = {
@@ -1715,7 +1754,8 @@ class CMISClientDocumentTests(DMSMixin, TestCase):
         self.assertEqual(updated_doc.identificatie, identification)
         self.assertEqual(updated_doc.bronorganisatie, "159351741")
         self.assertEqual(
-            updated_doc.creatiedatum, properties["creatiedatum"],
+            updated_doc.creatiedatum,
+            properties["creatiedatum"],
         )
         self.assertEqual(updated_doc.titel, "detailed summary")
         self.assertEqual(updated_doc.auteur, "updated auteur")
@@ -1741,7 +1781,8 @@ class CMISClientDocumentTests(DMSMixin, TestCase):
         }
 
         document = self.cmis_client.create_document(
-            identification=identification, data=properties,
+            identification=identification,
+            data=properties,
         )
 
         new_properties = {
@@ -1771,7 +1812,9 @@ class CMISClientDocumentTests(DMSMixin, TestCase):
         content = io.BytesIO(b"some file content")
 
         document = self.cmis_client.create_document(
-            identification=identification, data=properties, content=content,
+            identification=identification,
+            data=properties,
+            content=content,
         )
 
         # Make a different folder

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -418,7 +418,9 @@ class CMISDocumentTests(DMSMixin, TestCase):
 
         # Document created in temporary folder
         document = self.cmis_client.create_document(
-            identification=identification, data=properties, content=content,
+            identification=identification,
+            data=properties,
+            content=content,
         )
 
         parent_folder = document.get_parent_folders()[0]
@@ -536,7 +538,8 @@ class CMISContentObjectsTests(DMSMixin, TestCase):
             "Een hele set onredelijke voorwaarden",
         )
         self.assertNotIn(
-            "drc:gebruiksrechten__uuid", properties,
+            "drc:gebruiksrechten__uuid",
+            properties,
         )
 
     @skipIf(
@@ -558,13 +561,16 @@ class CMISContentObjectsTests(DMSMixin, TestCase):
             "http://some.test.url/d06f86e0-1c3a-49cf-b5cd-01c079cf8147",
         )
         self.assertEqual(
-            properties["drc:oio__object_type"]["value"], "besluit",
+            properties["drc:oio__object_type"]["value"],
+            "besluit",
         )
         self.assertEqual(
-            properties["drc:oio__besluit"]["value"], "http://another.test.url/",
+            properties["drc:oio__besluit"]["value"],
+            "http://another.test.url/",
         )
         self.assertNotIn(
-            "drc:oio__uuid", properties,
+            "drc:oio__uuid",
+            properties,
         )
 
     @skipIf(
@@ -596,7 +602,8 @@ class CMISContentObjectsTests(DMSMixin, TestCase):
             "Een hele set onredelijke voorwaarden",
         )
         self.assertNotIn(
-            "drc:gebruiksrechten__uuid", properties,
+            "drc:gebruiksrechten__uuid",
+            properties,
         )
 
     @skipIf(
@@ -618,13 +625,16 @@ class CMISContentObjectsTests(DMSMixin, TestCase):
             "http://some.test.url/d06f86e0-1c3a-49cf-b5cd-01c079cf8147",
         )
         self.assertEqual(
-            properties["drc:oio__object_type"], "besluit",
+            properties["drc:oio__object_type"],
+            "besluit",
         )
         self.assertEqual(
-            properties["drc:oio__besluit"], "http://another.test.url/",
+            properties["drc:oio__besluit"],
+            "http://another.test.url/",
         )
         self.assertNotIn(
-            "drc:oio__uuid", properties,
+            "drc:oio__uuid",
+            properties,
         )
 
 

--- a/tests/test_path_validators.py
+++ b/tests/test_path_validators.py
@@ -78,10 +78,12 @@ class FolderStructureTests(TestCase):
 
 class ZakenFolderPathValidatorTests(TestCase):
     def test_default_zaak_folder_path(self):
-        zaak_folder_path_validator(
-            CMISConfig._meta.get_field("zaak_folder_path").default
-        )
-        self.assert_(True)
+        try:
+            zaak_folder_path_validator(
+                CMISConfig._meta.get_field("zaak_folder_path").default
+            )
+        except ValidationError:
+            self.fail("Validator should pass")
 
     def test_missing_required_folder(self):
         with self.assertRaises(ValidationError):
@@ -94,10 +96,12 @@ class ZakenFolderPathValidatorTests(TestCase):
 
 class OtherFolderPathValidatorTests(TestCase):
     def test_default_other_folder_path(self):
-        other_folder_path_validator(
-            CMISConfig._meta.get_field("other_folder_path").default
-        )
-        self.assert_(True)
+        try:
+            other_folder_path_validator(
+                CMISConfig._meta.get_field("other_folder_path").default
+            )
+        except ValidationError:
+            self.fail("Validator should pass")
 
     def test_invalid_template_folder_folder(self):
         with self.assertRaises(ValidationError):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,7 +4,10 @@ from typing import Optional
 
 from requests_mock import Mocker
 
-MOCK_FILES_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), "responses",)
+MOCK_FILES_DIR = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)),
+    "responses",
+)
 
 
 def mock_service_oas_get(

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,12 @@ DJANGO =
     2.2: django22
     3.0: django30
 
+CMIS_BINDING =
+    BROWSER: browser
+    WEBSERVICE: webservice
+
 [testenv]
-passenv = CI TRAVIS TRAVIS_*
+passenv = CI TRAVIS TRAVIS_* CMIS_BINDING
 setenv =
     DJANGO_SETTINGS_MODULE = test_app.settings
     PYTHONPATH = {toxinidir}
@@ -28,24 +32,6 @@ commands =
   py.test tests/ \
    --cov=drc_cmis --cov-report xml:reports/coverage-{envname}.xml \
    {posargs}
-
-[webservice]
-description = Tests CMIS browser binding
-setenv =
-    CMIS_BINDING = BROWSER
-
-[browser]
-description = Tests CMIS webservice binding
-setenv =
-    CMIS_BINDING = WEBSERVICE
-
-[testenv:py{37,38}-django{22,30}-browser]
-setenv =
-    {[browser]setenv}
-
-[testenv:py{37,38}-django{22,30}-webservice]
-setenv =
-    {[webservice]setenv}
 
 [testenv:isort]
 extras = tests

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,6 @@ deps =
   django30: Django~=3.0.0
 commands =
   py.test tests/ \
-   --junitxml=reports/junit.xml \
    --cov=drc_cmis --cov-report xml:reports/coverage-{envname}.xml \
    {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,6 @@ passenv = CI TRAVIS TRAVIS_* CMIS_BINDING
 setenv =
     DJANGO_SETTINGS_MODULE = test_app.settings
     PYTHONPATH = {toxinidir}
-    CMIS_BINDING = BROWSER
 extras =
     tests
     coverage


### PR DESCRIPTION
Issue seems to be that codecov can't find the coverage report (XML)

-> we output the report per tox env (for local environments, so that they don't overwrite)

Using the env build matrix expansion, we can build the correct path to the file, and then explicitly point codecov to the correct file.

Tested using:

```bash
export TRAVIS=y TRAVIS_OS_NAME=linux TRAVIS_LANGUAGE=python TRAVIS_PYTHON_VERSION=3.8 DJANGO=2.2 CMIS_BINDING=BROWSER
tox --notest
tox
```