### PR TITLE
Issue 18 filter docs by zaak folder

### DIFF
--- a/drc_cmis/browser/client.py
+++ b/drc_cmis/browser/client.py
@@ -290,12 +290,14 @@ class CMISDRCClient(CMISClient, CMISRequest):
         identification: str,
         data: dict,
         content: BytesIO = None,
+        destination_folder: Folder = None,
     ) -> Document:
         """Create a cmis document.
 
         :param identification: string, A unique identifier for the document.
         :param data: dict, A dict with all the data that needs to be saved on the document.
         :param content: BytesIO, The content of the document.
+        :param destination_folder: Folder, the folder in which to place the document
         :return: document
         """
         logger.debug("CMIS_CLIENT: create_document")
@@ -311,13 +313,14 @@ class CMISDRCClient(CMISClient, CMISRequest):
             content = BytesIO()
 
         # Create Document in default folder
-        other_folder = self.get_or_create_other_folder()
+        if destination_folder is None:
+            destination_folder = self.get_or_create_other_folder()
 
         properties = Document.build_properties(
             data, new=True, identification=identification
         )
 
-        data = create_json_request_body(other_folder, properties)
+        data = create_json_request_body(destination_folder, properties)
 
         json_response = self.post_request(self.root_folder_url, data=data)
         cmis_doc = Document(json_response)

--- a/drc_cmis/browser/drc_document.py
+++ b/drc_cmis/browser/drc_document.py
@@ -343,3 +343,16 @@ class ZaakFolder(CMISBaseObject):
     table = "drc:zaakfolder"
     name_map = ZAAK_MAP
     type_name = "zaak"
+
+    def get_children_documents(self) -> List[Document]:
+        """Get all the documents in a zaak folder
+
+        :return: list of documents
+        """
+        data = {
+            "cmisaction": "query",
+            "statement": f"SELECT * FROM drc:document WHERE IN_FOLDER('{self.objectId}')",
+        }
+        json_response = self.post_request(self.base_url, data=data)
+
+        return self.get_all_results(json_response, Document)

--- a/drc_cmis/webservice/client.py
+++ b/drc_cmis/webservice/client.py
@@ -472,13 +472,18 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
             return Gebruiksrechten(extracted_data[0])
 
     def create_document(
-        self, identification: str, data: dict, content: BytesIO = None
+        self,
+        identification: str,
+        data: dict,
+        content: BytesIO = None,
+        destination_folder: Folder = None,
     ) -> Document:
         """Create a custom Document (with the EnkelvoudigInformatieObject properties)
 
         :param identification: string, the document ``identificatie``
         :param data: dict, the properties of the document
         :param content: BytesIO, the content of the document
+        :param destination_folder: Folder, the folder in which to place the document
         :return: Document, the document created
         """
 
@@ -495,7 +500,8 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
             content = BytesIO()
 
         # Create Document in default folder
-        other_folder = self.get_or_create_other_folder()
+        if destination_folder is None:
+            destination_folder = self.get_or_create_other_folder()
 
         properties = Document.build_properties(
             data, new=True, identification=identification
@@ -504,7 +510,7 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
         soap_envelope = make_soap_envelope(
             auth=(self.user, self.password),
             repository_id=self.main_repo_id,
-            folder_id=other_folder.objectId,
+            folder_id=destination_folder.objectId,
             properties=properties,
             cmis_action="createDocument",
             content_id=content_id,


### PR DESCRIPTION
- Added a function that returns all the documents in a zaak folder.
- When an oio is created and it references a document in a zaak folder but without oio, the document is *copied* to the new zaak folder.