### PR TITLE
Fixes #24 - Creating binary documents

### DIFF
--- a/drc_cmis/webservice/drc_document.py
+++ b/drc_cmis/webservice/drc_document.py
@@ -373,7 +373,7 @@ class Document(CMISContentObject):
         )
 
         soap_response = self.request(
-            "ObjectService", soap_envelope=soap_envelope.toxml()
+            "ObjectService", soap_envelope=soap_envelope.toxml(), keep_binary=True
         )
 
         # FIXME find a better way to do this

--- a/drc_cmis/webservice/request.py
+++ b/drc_cmis/webservice/request.py
@@ -121,7 +121,9 @@ class SOAPCMISRequest:
             envelope_header += f"{key}: {value}\n"
 
         # Format the body of the request
-        body = f"\n{self._boundary}\n{envelope_header}\n{soap_envelope}\n\n"
+        body = f"\n{self._boundary}\n{envelope_header}\n{soap_envelope}\n\n".encode(
+            "utf-8"
+        )
 
         # Adding the attachments
         if attachments is not None:
@@ -136,11 +138,12 @@ class SOAPCMISRequest:
                 for key, value in file_attachment_headers.items():
                     xml_attachment_header += f"{key}: {value}\n"
 
-                attachment_content = attachment[1]
-                attachment_content.seek(0)
-                body += f"{self._boundary}\n{xml_attachment_header}\n{attachment_content.read().decode('UTF-8')}"
+                attachment_stream = attachment[1]
+                attachment_stream.seek(0)
+                body += f"{self._boundary}\n{xml_attachment_header}\n".encode("utf-8")
+                body += attachment_stream.read()  # Reads binary
 
-        body += f"{self._boundary}--\n"
+        body += f"{self._boundary}--\n".encode("utf-8")
         soap_response = requests.post(url, data=body, headers=self._headers, files=[])
         if not soap_response.ok:
             error = soap_response.text
@@ -201,4 +204,4 @@ class SOAPCMISRequest:
                     code=soap_response.status_code,
                 )
 
-        return soap_response.content.decode("UTF-8")
+        return soap_response.content

--- a/drc_cmis/webservice/request.py
+++ b/drc_cmis/webservice/request.py
@@ -1,4 +1,4 @@
-from typing import BinaryIO, List, Optional, Tuple
+from typing import BinaryIO, List, Optional, Tuple, Union
 
 import requests
 
@@ -104,7 +104,8 @@ class SOAPCMISRequest:
         path: str,
         soap_envelope: str,
         attachments: Optional[List[Tuple[str, BinaryIO]]] = None,
-    ) -> str:
+        keep_binary: bool = False,
+    ) -> Union[str, bytes]:
         """Make request with MTOM attachment.
 
         :param path: string, path where to post the request
@@ -112,7 +113,8 @@ class SOAPCMISRequest:
         (in the form of `cid:<contentId>`)
         :param attachments: list of tuples, each tuple contains the content ID used in the XML (string) and the I/O
         stream for the attachment.
-        :return: string, the content of the response
+        :param keep_binary: whether to keep the body of the response as binary or convert it to a string.
+        :return: string or bytes, the content of the response
         """
         url = f"{self.base_url}/{path.lstrip('/')}"
 
@@ -204,4 +206,6 @@ class SOAPCMISRequest:
                     code=soap_response.status_code,
                 )
 
-        return soap_response.content
+        if keep_binary:
+            return soap_response.content
+        return soap_response.content.decode("utf-8")

--- a/drc_cmis/webservice/utils.py
+++ b/drc_cmis/webservice/utils.py
@@ -140,7 +140,7 @@ def extract_content_stream_properties_from_xml(xml_data: str) -> dict:
 
 # FIXME find a better way to do this
 def extract_content(soap_response_body: str) -> BytesIO:
-    xml_response = extract_xml_from_soap(soap_response_body)
+    xml_response = extract_xml_from_soap(soap_response_body, binary=True)
     extracted_data = extract_content_stream_properties_from_xml(xml_response)
 
     # After the filename comes the file content
@@ -376,8 +376,14 @@ def make_soap_envelope(
     return xml_doc
 
 
-def extract_xml_from_soap(soap_response):
-    begin_xml = soap_response.find(b"<soap:Envelope")
-    end_xml = soap_response.find(b"</soap:Envelope>") + len(b"</soap:Envelope>")
+def extract_xml_from_soap(soap_response, binary=False):
+    soap_envelope_start = "<soap:Envelope"
+    soap_envelope_end = "</soap:Envelope>"
+    if binary:
+        soap_envelope_start = soap_envelope_start.encode("UTF-8")
+        soap_envelope_end = soap_envelope_end.encode("UTF-8")
+
+    begin_xml = soap_response.find(soap_envelope_start)
+    end_xml = soap_response.find(soap_envelope_end) + len(soap_envelope_end)
 
     return soap_response[begin_xml:end_xml]

--- a/drc_cmis/webservice/utils.py
+++ b/drc_cmis/webservice/utils.py
@@ -146,12 +146,16 @@ def extract_content(soap_response_body: str) -> BytesIO:
     # After the filename comes the file content
     last_header = (
         f"Content-Disposition: attachment;name=\"{extracted_data['filename']}\""
-    )
+    ).encode("utf-8")
     idx_content = soap_response_body.find(last_header) + len(last_header)
     content_with_boundary = soap_response_body[idx_content:]
-    content = re.search("\r\n\r\n(.+?)\r\n--uuid:.+?--", content_with_boundary).group(1)
+    content = re.search(
+        "\r\n\r\n(.+?)\r\n--uuid:.+?--".encode("utf-8"),
+        content_with_boundary,
+        re.DOTALL,
+    ).group(1)
 
-    return BytesIO(content.encode())
+    return BytesIO(content)
 
 
 def make_soap_envelope(
@@ -373,7 +377,7 @@ def make_soap_envelope(
 
 
 def extract_xml_from_soap(soap_response):
-    begin_xml = soap_response.find("<soap:Envelope")
-    end_xml = soap_response.find("</soap:Envelope>") + len("</soap:Envelope>")
+    begin_xml = soap_response.find(b"<soap:Envelope")
+    end_xml = soap_response.find(b"</soap:Envelope>") + len(b"</soap:Envelope>")
 
     return soap_response[begin_xml:end_xml]

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -108,6 +108,27 @@ class CMISDocumentTests(DMSMixin, TestCase):
         self.assertEqual(pwc.versionLabel, "pwc")
 
     @tag("alfresco")
+    def test_document_with_pdf_attachment(self):
+        identification = str(uuid.uuid4())
+        data = {
+            "creatiedatum": datetime.date(2020, 7, 27),
+            "titel": "detailed summary",
+        }
+        # Contains non-UTF-8 characters
+        content = io.BytesIO(
+            b"%PDF-1.4\n%\xc3\xa4\xc3\xbc\xc3\xb6\n2 0 obj\n<</Length 3 0 R/Filter/FlateDecode>>\nstream\nx\x9c"
+        )
+        document = self.cmis_client.create_document(
+            identification=identification,
+            data=data,
+            content=content,
+        )
+
+        posted_content = document.get_content_stream()
+        content.seek(0)
+        self.assertEqual(posted_content.read(), content.read())
+
+    @tag("alfresco")
     def test_checkin_document(self):
         identification = str(uuid.uuid4())
         data = {


### PR DESCRIPTION
Fixes #24 

Binary documents can also be created now without causing an error. 