### PR TITLE
Changes after testing with Corsa

### DIFF
--- a/drc_cmis/browser/client.py
+++ b/drc_cmis/browser/client.py
@@ -113,14 +113,12 @@ class CMISDRCClient(CMISClient, CMISRequest):
 
         return Folder(json_response)
 
-    def get_folder(self, uuid: str) -> Folder:
-        """Retrieve folder with objectId constructed with the uuid given"""
+    def get_folder(self, object_id: str) -> Folder:
+        """Retrieve folder with objectId given"""
 
-        query = CMISQuery(
-            "SELECT * FROM cmis:folder WHERE cmis:objectId = 'workspace://SpacesStore/%s'"
-        )
+        query = CMISQuery("SELECT * FROM cmis:folder WHERE cmis:objectId = '%s'")
 
-        body = {"cmisaction": "query", "statement": query(uuid)}
+        body = {"cmisaction": "query", "statement": query(object_id)}
         logger.debug("CMIS_ADAPTER: get_folder: request data: %s", body)
         json_response = self.post_request(self.base_url, body)
         logger.debug("CMIS_ADAPTER: get_folder: response data: %s", json_response)
@@ -128,7 +126,9 @@ class CMISDRCClient(CMISClient, CMISRequest):
         try:
             return self.get_first_result(json_response, Folder)
         except GetFirstException:
-            error_string = f"Folder met objectId 'workspace://SpacesStore/{uuid}' bestaat niet in het CMIS connection"
+            error_string = (
+                f"Folder met objectId '{object_id}' bestaat niet in het CMIS connection"
+            )
             raise FolderDoesNotExistError(error_string)
 
     def copy_gebruiksrechten(

--- a/drc_cmis/browser/drc_document.py
+++ b/drc_cmis/browser/drc_document.py
@@ -356,10 +356,29 @@ class ObjectInformatieObject(CMISContentObject):
 class Folder(CMISBaseObject):
     table = "cmis:folder"
 
-    def get_children_folders(self):
+    def get_children_folders(self, child_type: Union[str, dict] = None) -> List:
+        """Get all the folders in the current folder
+
+        :param child_type: str or dict, Contains the object type ID of the children folders to retrieve.
+        If it is a dict, then the child type is the value of the key "value".
+        """
+
+        if child_type is not None:
+            if isinstance(child_type, dict):
+                object_type_id = child_type["value"]
+            else:
+                object_type_id = child_type
+
+            # Alfresco case: the object type ID has an extra prefix (F:drc:zaakfolder, instead of drc:zaakfolder)
+            # The prefix needs to be removed for the query
+            if len(object_type_id.split(":")) > 2:
+                object_type_id = ":".join(object_type_id.split(":")[1:])
+        else:
+            object_type_id = "cmis:folder"
+
         data = {
             "cmisaction": "query",
-            "statement": f"SELECT * FROM cmis:folder WHERE IN_FOLDER('{self.objectId}')",
+            "statement": f"SELECT * FROM {object_type_id} WHERE IN_FOLDER('{self.objectId}')",
         }
         logger.debug("CMIS_ADAPTER: get_children_folders: request data: %s", data)
         json_response = self.post_request(self.base_url, data=data)

--- a/drc_cmis/client.py
+++ b/drc_cmis/client.py
@@ -100,8 +100,12 @@ class CMISClient:
         :param properties: dict, contains the properties of the folder to create
         :return: Folder, the folder that was created/retrieved
         """
+        if properties is None:
+            child_type = None
+        else:
+            child_type = properties.get("cmis:objectTypeId")
 
-        children_folders = parent.get_children_folders()
+        children_folders = parent.get_children_folders(child_type=child_type)
         for folder in children_folders:
             if folder.name == name:
                 return folder
@@ -110,7 +114,9 @@ class CMISClient:
         return self.create_folder(name, parent.objectId, properties)
 
     def get_folder_by_name(self, name: str, parent: Folder) -> Folder:
-        children_folders = parent.get_children_folders()
+        children_folders = parent.get_children_folders(
+            child_type=parent.properties.get("cmis:objectTypeId")
+        )
         for folder in children_folders:
             if folder.name == name:
                 return folder

--- a/drc_cmis/webservice/drc_document.py
+++ b/drc_cmis/webservice/drc_document.py
@@ -554,10 +554,23 @@ class ObjectInformatieObject(CMISContentObject):
 class Folder(CMISBaseObject):
     table = "cmis:folder"
 
-    def get_children_folders(self) -> List:
-        """Get all the folders in the current folder"""
+    def get_children_folders(self, child_type: dict = None) -> List:
+        """Get all the folders in the current folder
 
-        query = CMISQuery("SELECT * FROM cmis:folder WHERE cmis:parentId = '%s'")
+        :param child_type: dict, With keys "value" and "type". The value contains the object type ID of
+        the children folders to retrieve.
+        """
+
+        if child_type is not None:
+            object_type_id = child_type["value"]
+            # Alfresco case: the object type ID has an extra prefix (F:drc:zaakfolder, instead of drc:zaakfolder)
+            # The prefix needs to be removed for the query
+            if len(object_type_id.split(":")) > 2:
+                object_type_id = ":".join(object_type_id.split(":")[1:])
+        else:
+            object_type_id = "cmis:folder"
+
+        query = CMISQuery(f"SELECT * FROM {object_type_id} WHERE cmis:parentId = '%s'")
 
         soap_envelope = make_soap_envelope(
             auth=(self.user, self.password),

--- a/drc_cmis/webservice/utils.py
+++ b/drc_cmis/webservice/utils.py
@@ -139,19 +139,12 @@ def extract_content_stream_properties_from_xml(xml_data: str) -> dict:
 
 
 # FIXME find a better way to do this
-def extract_content(soap_response_body: str) -> BytesIO:
-    xml_response = extract_xml_from_soap(soap_response_body, binary=True)
-    extracted_data = extract_content_stream_properties_from_xml(xml_response)
-
-    # After the filename comes the file content
-    last_header = (
-        f"Content-Disposition: attachment;name=\"{extracted_data['filename']}\""
-    ).encode("utf-8")
-    idx_content = soap_response_body.find(last_header) + len(last_header)
-    content_with_boundary = soap_response_body[idx_content:]
+def extract_content(soap_response_body: bytes) -> BytesIO:
     content = re.search(
-        "\r\n\r\n(.+?)\r\n--uuid:.+?--".encode("utf-8"),
-        content_with_boundary,
+        "Content-Disposition: attachment;.+?\r\n\r\n(.+?)\r\n--uuid:.+?--".encode(
+            "utf-8"
+        ),
+        soap_response_body,
         re.DOTALL,
     ).group(1)
 

--- a/test_app/manage.py
+++ b/test_app/manage.py
@@ -2,9 +2,9 @@
 import os
 import sys
 
+from django.core.management import execute_from_command_line
+
 if __name__ == "__main__":
     os.environ["DJANGO_SETTINGS_MODULE"] = "settings"
 
-    from django.core.management import execute_from_command_line
-
-execute_from_command_line(sys.argv)
+    execute_from_command_line(sys.argv)

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -186,6 +186,29 @@ class CMISClientFolderTests(DMSMixin, TestCase):
         self.assertEqual(retrieved_folder.name, "TestFolder")
         self.assertEqual(retrieved_folder.objectId, new_folder_id)
 
+    def test_get_or_create_zaak_folder_when_folder_exist(self):
+        zaaktype = {
+            "url": "https://ref.tst.vng.cloud/ztc/api/v1/zaaktypen/0119dd4e-7be9-477e-bccf-75023b1453c1",
+            "identificatie": 1,
+            "omschrijving": "Melding Openbare Ruimte",
+            "object_type_id": f"{self.cmis_client.get_object_type_id_prefix('zaaktypefolder')}drc:zaaktypefolder",
+        }
+        zaak = {
+            "url": "https://ref.tst.vng.cloud/zrc/api/v1/zaken/random-zaak-uuid",
+            "identificatie": "1bcfd0d6-c817-428c-a3f4-4047038c184d",
+            "zaaktype": "https://ref.tst.vng.cloud/ztc/api/v1/zaaktypen/0119dd4e-7be9-477e-bccf-75023b1453c1",
+            "bronorganisatie": "509381406",
+            "object_type_id": f"{self.cmis_client.get_object_type_id_prefix('zaakfolder')}drc:zaakfolder",
+        }
+        created_zaak_folder = self.cmis_client.get_or_create_zaak_folder(
+            zaaktype=zaaktype, zaak=zaak
+        )
+        retrieved_zaak_folder = self.cmis_client.get_or_create_zaak_folder(
+            zaaktype=zaaktype, zaak=zaak
+        )
+
+        self.assertEqual(created_zaak_folder.objectId, retrieved_zaak_folder.objectId)
+
     def test_delete_other_base_folder(self):
         base_folder = self.cmis_client.get_or_create_other_folder()
         folder1 = self.cmis_client.create_folder("TestFolder1", base_folder.objectId)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,19 @@
+from django.test import TestCase
+
+from drc_cmis.webservice.utils import extract_content
+
+
+class WebserviceUtilsTests(TestCase):
+    def test_extract_content_from_corsa_response(self):
+        corsa_response = b'--uuid:8e14725d-a58b-4532-98be-27ed9226f17f\r\nContent-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\nContent-Transfer-Encoding: binary\r\nContent-ID: <root.message@cxf.apache.org>\r\n\r\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><SOAP-ENV:Header xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"><wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" soap:mustUnderstand="1"><wsu:Timestamp wsu:Id="TS-d88631cd-fdef-45c0-8e70-2f34873df125"><wsu:Created>2020-12-03T12:32:28.515Z</wsu:Created><wsu:Expires>2020-12-03T12:37:28.515Z</wsu:Expires></wsu:Timestamp></wsse:Security></SOAP-ENV:Header><soap:Body><getContentStreamResponse xmlns="http://docs.oasis-open.org/ns/cmis/messaging/200908/" xmlns:ns2="http://docs.oasis-open.org/ns/cmis/core/200908/"><contentStream><length>17</length><mimeType>application/octet-stream</mimeType><filename>filename</filename><stream><xop:Include xmlns:xop="http://www.w3.org/2004/08/xop/include" href="cid:7878fd49-6f1d-4d2f-9a38-54df57d1c08a-11@http%3A%2F%2Fdocs.oasis-open.org%2Fns%2Fcmis%2Fmessaging%2F200908%2F"/></stream></contentStream></getContentStreamResponse></soap:Body></soap:Envelope>\r\n--uuid:8e14725d-a58b-4532-98be-27ed9226f17f\r\nContent-Type: application/octet-stream\r\nContent-Transfer-Encoding: binary\r\nContent-ID: <7878fd49-6f1d-4d2f-9a38-54df57d1c08a-11@http://docs.oasis-open.org/ns/cmis/messaging/200908/>\r\nContent-Disposition: attachment;name="1c41733e-aae9-45ac-840c-2cd5aa00c2a8.TMP366060064106742183.tmp"\r\n\r\nsome file content\r\n--uuid:8e14725d-a58b-4532-98be-27ed9226f17f--'
+        content_stream = extract_content(corsa_response)
+        content = content_stream.read()
+
+        self.assertEqual(content, b"some file content")
+
+    def test_extract_content_from_alfresco_response(self):
+        alfresco_response = b'\r\n--uuid:b4e1dca5-7b02-4697-a602-8650e3e41ce4\r\nContent-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\nContent-Transfer-Encoding: binary\r\nContent-ID: <root.message@cxf.apache.org>\r\n\r\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><getContentStreamResponse xmlns="http://docs.oasis-open.org/ns/cmis/messaging/200908/" xmlns:ns2="http://docs.oasis-open.org/ns/cmis/core/200908/"><contentStream><length>17</length><mimeType>text/plain</mimeType><filename>detailed summary-KJJY4M (Working Copy)</filename><stream><xop:Include xmlns:xop="http://www.w3.org/2004/08/xop/include" href="cid:1009d1c8-3689-469f-816b-f06d595aedd8-1@docs.oasis-open.org"/></stream></contentStream></getContentStreamResponse></soap:Body></soap:Envelope>\r\n--uuid:b4e1dca5-7b02-4697-a602-8650e3e41ce4\r\nContent-Type: text/plain\r\nContent-Transfer-Encoding: binary\r\nContent-ID: <1009d1c8-3689-469f-816b-f06d595aedd8-1@docs.oasis-open.org>\r\nContent-Disposition: attachment;name="detailed summary-KJJY4M (Working Copy)"\r\n\r\nsome file content\r\n--uuid:b4e1dca5-7b02-4697-a602-8650e3e41ce4--'
+        content_stream = extract_content(alfresco_response)
+        content = content_stream.read()
+
+        self.assertEqual(content, b"some file content")


### PR DESCRIPTION
*Changes*

1. The extraction of a file content from a SOAP response has been updated. Now the regex expression that finds where the content is within the SOAP envelope has been updated so that it also matches the Corsa response.

2. The `manage.py` of the test app had a line that was not indented properly and I was always modifying it locally to run the tests. Now I decided to change it for convenience.

3. In Alfresco, when doing a query such as `SELECT * FROM cmis:folder`, both folders with base type ID and object type ID equal to `cmis:folder` are retrieved. In corsa, only those with object type ID. So queries were changed to take this into account.