### PR TITLE
Made WEBSERVICE binding logs more readable

### DIFF
--- a/drc_cmis/webservice/client.py
+++ b/drc_cmis/webservice/client.py
@@ -48,6 +48,7 @@ from drc_cmis.webservice.utils import (
     extract_repo_info_from_xml,
     extract_xml_from_soap,
     make_soap_envelope,
+    pretty_xml,
 )
 
 logger = logging.getLogger(__name__)
@@ -70,20 +71,14 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
             cmis_action="getRepositoryInfo",
         )
 
-        logger.debug(
-            "get_repository_info: SOAP getRepositoryInfo request: %s",
-            soap_envelope.toxml(),
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         soap_response = self.request(
             "RepositoryService", soap_envelope=soap_envelope.toxml()
         )
 
-        logger.debug(
-            "get_repository_info: SOAP getRepositoryInfo response: %s", soap_response
-        )
-
         xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
 
         return extract_repo_info_from_xml(xml_response)
 
@@ -115,9 +110,7 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
             cmis_action="query",
         )
 
-        logger.debug(
-            "CMIS_ADAPTER: query: SOAP query request: %s", soap_envelope.toxml()
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         try:
             soap_response = self.request(
@@ -130,9 +123,10 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
             else:
                 raise exc
 
-        logger.debug("CMIS_ADAPTER: query: SOAP query response: %s", soap_response)
-
         xml_response = extract_xml_from_soap(soap_response)
+
+        logger.debug(pretty_xml(xml_response))
+
         extracted_data = extract_object_properties_from_xml(xml_response, "query")
 
         return [return_type(cmis_object) for cmis_object in extracted_data]
@@ -165,18 +159,14 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
             cmis_action="createFolder",
         )
 
-        logger.debug(
-            "create_folder: SOAP createFolder request: %s", soap_envelope.toxml()
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         soap_response = self.request(
             "ObjectService", soap_envelope=soap_envelope.toxml()
         )
-        logger.debug(
-            "CMIS_ADAPTER: create_folder: SOAP createFolder response: %s", soap_response
-        )
-
         xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
+
         extracted_data = extract_object_properties_from_xml(
             xml_response, "createFolder"
         )[0]
@@ -196,10 +186,7 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
             cmis_action="getObject",
         )
 
-        logger.debug(
-            "CMIS_ADAPTER: get_folder: SOAP getObject request: %s",
-            soap_envelope.toxml(),
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         try:
             soap_response = self.request(
@@ -212,11 +199,9 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
             else:
                 raise exc
 
-        logger.debug(
-            "CMIS_ADAPTER: get_folder: SOAP getObject response: %s", soap_response
-        )
-
         xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
+
         extracted_data = extract_object_properties_from_xml(xml_response, "getObject")[
             0
         ]
@@ -278,9 +263,7 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
             content_id=content_id,
         )
 
-        logger.debug(
-            "copy_document: SOAP createDocument request: %s", soap_envelope.toxml()
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         soap_response = self.request(
             "ObjectService",
@@ -288,13 +271,10 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
             attachments=[(content_id, document.get_content_stream())],
         )
 
-        logger.debug(
-            "CMIS_ADAPTER: copy_document: SOAP createDocument response: %s",
-            soap_response,
-        )
-
         # Creating the document only returns its ID
         xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
+
         extracted_data = extract_object_properties_from_xml(
             xml_response, "createDocument"
         )[0]
@@ -350,22 +330,18 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
             properties=cmis_properties,
             cmis_action="createDocument",
         )
-        logger.debug(
-            "copy_gebruiksrechten: SOAP createDocument request: %s",
-            soap_envelope.toxml(),
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         soap_response = self.request(
             "ObjectService",
             soap_envelope=soap_envelope.toxml(),
         )
 
-        logger.debug(
-            "copy_gebruiksrechten: SOAP createDocument response: %s", soap_response
-        )
-
         # Creating the document only returns its ID
         xml_response = extract_xml_from_soap(soap_response)
+
+        logger.debug(pretty_xml(xml_response))
+
         extracted_data = extract_object_properties_from_xml(
             xml_response, "createDocument"
         )[0]
@@ -379,20 +355,15 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
             cmis_action="getObject",
         )
 
-        logger.debug(
-            "copy_gebruiksrechten: SOAP getObject request: %s", soap_envelope.toxml()
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         soap_response = self.request(
             "ObjectService", soap_envelope=soap_envelope.toxml()
         )
 
-        logger.debug(
-            "CMIS_ADAPTER: copy_gebruiksrechten: SOAP getObject response: %s",
-            soap_response,
-        )
-
         xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
+
         extracted_data = extract_object_properties_from_xml(xml_response, "getObject")[
             0
         ]
@@ -450,21 +421,16 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
             cmis_action="createDocument",
         )
 
-        logger.debug(
-            "create_content_object: SOAP createDocument request: %s",
-            soap_envelope.toxml(),
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         soap_response = self.request(
             "ObjectService",
             soap_envelope=soap_envelope.toxml(),
         )
 
-        logger.debug(
-            "create_content_object: SOAP createDocument response: %s", soap_response
-        )
-
         xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
+
         extracted_data = extract_object_properties_from_xml(
             xml_response, "createDocument"
         )[0]
@@ -478,19 +444,15 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
             cmis_action="getObject",
         )
 
-        logger.debug(
-            "create_content_object: SOAP getObject request: %s", soap_envelope.toxml()
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         soap_response = self.request(
             "ObjectService", soap_envelope=soap_envelope.toxml()
         )
 
-        logger.debug(
-            "create_content_object: SOAP getObject response: %s", soap_response
-        )
-
         xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
+
         extracted_data = extract_object_properties_from_xml(xml_response, "getObject")[
             0
         ]
@@ -521,9 +483,7 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
             cmis_action="query",
         )
 
-        logger.debug(
-            "get_content_object: SOAP getObject request: %s", soap_envelope.toxml()
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         error_string = (
             f"{object_type.capitalize()} {object_type} met identificatie drc:{object_type}__uuid {drc_uuid} "
@@ -541,12 +501,9 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
                 raise does_not_exist
             else:
                 raise exc
-        logger.debug(
-            "CMIS_ADAPTER: get_content_object: SOAP getObject response: %s",
-            soap_response,
-        )
 
         xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
 
         extracted_data = extract_object_properties_from_xml(xml_response, "query")
         if len(extracted_data) == 0:
@@ -602,21 +559,17 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
             content_id=content_id,
         )
 
-        logger.debug(
-            "create_document: SOAP createDocument request: %s", soap_envelope.toxml()
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         soap_response = self.request(
             "ObjectService",
             soap_envelope=soap_envelope.toxml(),
             attachments=[(content_id, content)],
         )
-        logger.debug(
-            "CMIS_ADAPTER: create_document: SOAP createDocument response: %s",
-            soap_response,
-        )
 
         xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
+
         # Creating the document only returns its ID
         extracted_data = extract_object_properties_from_xml(
             xml_response, "createDocument"
@@ -630,18 +583,14 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
             object_id=new_document_id,
             cmis_action="getObject",
         )
-        logger.debug(
-            "create_document: SOAP getObject request: %s", soap_envelope.toxml()
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         soap_response = self.request(
             "ObjectService", soap_envelope=soap_envelope.toxml()
         )
-        logger.debug(
-            "CMIS_ADAPTER: create_document: SOAP getObject response: %s", soap_response
-        )
-
         xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
+
         extracted_data = extract_object_properties_from_xml(xml_response, "getObject")[
             0
         ]
@@ -737,9 +686,7 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
             statement=query(drc_uuid, filter_string),
             cmis_action="query",
         )
-        logger.debug(
-            "CMIS_ADAPTER: get_document: SOAP query request: %s", soap_envelope.toxml()
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         try:
             soap_response = self.request(
@@ -751,11 +698,9 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
                 raise does_not_exist
             else:
                 raise exc
-        logger.debug(
-            "CMIS_ADAPTER: get_document: SOAP query response: %s", soap_response
-        )
-
         xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
+
         extracted_data = extract_object_properties_from_xml(xml_response, "query")
         return extract_latest_version(self.document_type, extracted_data)
 
@@ -780,9 +725,7 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
             statement=query(str(identification), bronorganisatie),
             cmis_action="query",
         )
-        logger.debug(
-            "check_document_exists: SOAP query request: %s", soap_envelope.toxml()
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         try:
             soap_response = self.request(
@@ -794,12 +737,10 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
                 return
             else:
                 raise exc
-        logger.debug(
-            "CMIS_ADAPTER: check_document_exists: SOAP query response: %s",
-            soap_response,
-        )
 
         xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
+
         extracted_data = extract_object_properties_from_xml(xml_response, "query")
 
         if len(extracted_data) > 0:

--- a/drc_cmis/webservice/drc_document.py
+++ b/drc_cmis/webservice/drc_document.py
@@ -32,6 +32,7 @@ from drc_cmis.webservice.utils import (
     extract_object_properties_from_xml,
     extract_xml_from_soap,
     make_soap_envelope,
+    pretty_xml,
 )
 
 logger = logging.getLogger(__name__)
@@ -118,15 +119,14 @@ class CMISContentObject(CMISBaseObject):
             object_id=self.objectId,
             cmis_action="deleteObject",
         )
-        logger.debug(
-            "delete_object: SOAP deleteObject request: %s", soap_envelope.toxml()
+        logger.debug(soap_envelope.toprettyxml())
+
+        soap_response = self.request(
+            "ObjectService", soap_envelope=soap_envelope.toxml()
         )
 
-        response = self.request("ObjectService", soap_envelope=soap_envelope.toxml())
-
-        logger.debug(
-            "CMIS_ADAPTER: delete_object: SOAP deleteObject response: %s", response
-        )
+        xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
 
     def get_parent_folders(self) -> List["Folder"]:
         """Get all the parent folders of an object"""
@@ -137,19 +137,13 @@ class CMISContentObject(CMISBaseObject):
             object_id=self.objectId,
             cmis_action="getObjectParents",
         )
-        logger.debug(
-            "get_parent_folders: SOAP getObjectParents request: %s",
-            soap_envelope.toxml(),
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         soap_response = self.request(
             "NavigationService", soap_envelope=soap_envelope.toxml()
         )
-        logger.debug(
-            "get_parent_folders: SOAP getObjectParents response: %s", soap_response
-        )
-
         xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
 
         extracted_data = extract_object_properties_from_xml(
             xml_response, "getObjectParents"
@@ -169,19 +163,13 @@ class CMISContentObject(CMISBaseObject):
             source_folder_id=source_folder.objectId,
             cmis_action="moveObject",
         )
-        logger.debug(
-            "CMIS_ADAPTER: move_object: SOAP moveObject request: %s",
-            soap_envelope.toxml(),
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         soap_response = self.request(
             "ObjectService", soap_envelope=soap_envelope.toxml()
         )
-        logger.debug(
-            "CMIS_ADAPTER: move_object: SOAP moveObject response: %s", soap_response
-        )
-
         xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
         extracted_data = extract_object_properties_from_xml(xml_response, "moveObject")[
             0
         ]
@@ -279,19 +267,13 @@ class Document(CMISContentObject):
             object_id=object_id,
             cmis_action="getObject",
         )
-        logger.debug(
-            "CMIS_ADAPTER: get_document: SOAP getObject request: %s",
-            soap_envelope.toxml(),
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         soap_response = self.request(
             "ObjectService", soap_envelope=soap_envelope.toxml()
         )
-        logger.debug(
-            "CMIS_ADAPTER: get_document: SOAP getObject response: %s", soap_response
-        )
-
         xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
         extracted_data = extract_object_properties_from_xml(xml_response, "getObject")[
             0
         ]
@@ -307,20 +289,15 @@ class Document(CMISContentObject):
             cmis_action="checkOut",
             object_id=str(self.objectId),
         )
-        logger.debug(
-            "CMIS_ADAPTER: checkout: SOAP checkOut request: %s", soap_envelope.toxml()
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         # FIXME temporary solution due to alfresco raising a 500 AFTER locking the document
         try:
             soap_response = self.request(
                 "VersioningService", soap_envelope=soap_envelope.toxml()
             )
-            logger.debug(
-                "CMIS_ADAPTER: checkout: SOAP checkOut response: %s", soap_response
-            )
-
             xml_response = extract_xml_from_soap(soap_response)
+            logger.debug(pretty_xml(xml_response))
             extracted_data = extract_object_properties_from_xml(
                 xml_response, "checkOut"
             )[0]
@@ -340,16 +317,14 @@ class Document(CMISContentObject):
             major=str(major).lower(),
             checkin_comment=checkin_comment,
         )
-        logger.debug(
-            "CMIS_ADAPTER: checkin: SOAP checkIn request: %s", soap_envelope.toxml()
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         soap_response = self.request(
             "VersioningService", soap_envelope=soap_envelope.toxml()
         )
-        logger.debug("CMIS_ADAPTER: checkin: SOAP checkIn response: %s", soap_response)
-
         xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
+
         extracted_data = extract_object_properties_from_xml(xml_response, "checkIn")[0]
         doc_id = extracted_data["properties"]["objectId"]["value"]
 
@@ -363,16 +338,12 @@ class Document(CMISContentObject):
             cmis_action="getAllVersions",
             object_id=object_id,
         )
-        logger.debug(
-            "get_all_versions: SOAP getAllVersions request: %s", soap_envelope.toxml()
-        )
+        logger.debug(soap_envelope.toprettyxml())
         soap_response = self.request(
             "VersioningService", soap_envelope=soap_envelope.toxml()
         )
-        logger.debug(
-            "get_all_versions: SOAP getAllVersions response: %s", soap_response
-        )
         xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
         extracted_data = extract_object_properties_from_xml(
             xml_response, "getAllVersions"
         )
@@ -400,20 +371,14 @@ class Document(CMISContentObject):
             cmis_action="updateProperties",
             object_id=self.objectId,
         )
-        logger.debug(
-            "update_properties: SOAP updateProperties request: %s",
-            soap_envelope.toxml(),
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         soap_response = self.request(
             "ObjectService",
             soap_envelope=soap_envelope.toxml(),
         )
-        logger.debug(
-            "update_properties: SOAP updateProperties response: %s", soap_response
-        )
-
         xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
         extracted_data = extract_object_properties_from_xml(
             xml_response, "updateProperties"
         )[0]
@@ -426,17 +391,14 @@ class Document(CMISContentObject):
             object_id=self.objectId,
             cmis_action="getContentStream",
         )
-        logger.debug(
-            "get_content_stream: SOAP getContentStream request: %s",
-            soap_envelope.toxml(),
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         soap_response = self.request(
             "ObjectService", soap_envelope=soap_envelope.toxml(), keep_binary=True
         )
-        logger.debug(
-            "get_content_stream: SOAP getContentStream response: %s", soap_response
-        )
+
+        xml_response = extract_xml_from_soap(soap_response, binary=True)
+        logger.debug(pretty_xml(xml_response))
 
         # FIXME find a better way to do this
         return extract_content(soap_response)
@@ -452,19 +414,15 @@ class Document(CMISContentObject):
             cmis_action="setContentStream",
             content_id=content_id,
         )
-        logger.debug(
-            "set_content_stream: SOAP setContentStream request: %s",
-            soap_envelope.toxml(),
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         soap_response = self.request(
             "ObjectService",
             soap_envelope=soap_envelope.toxml(),
             attachments=attachments,
         )
-        logger.debug(
-            "set_content_stream: SOAP setContentStream response: %s", soap_response
-        )
+        xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
 
     def delete_object(self):
         """
@@ -483,17 +441,14 @@ class Document(CMISContentObject):
                 object_id=latest_version.objectId,
                 cmis_action="cancelCheckOut",
             )
-            logger.debug(
-                "delete_object: SOAP cancelCheckOut request: %s", soap_envelope.toxml()
-            )
+            logger.debug(soap_envelope.toprettyxml())
 
             soap_response = self.request(
                 "VersioningService",
                 soap_envelope=soap_envelope.toxml(),
             )
-            logger.debug(
-                "delete_object: SOAP cancelCheckOut response: %s", soap_response
-            )
+            xml_response = extract_xml_from_soap(soap_response)
+            logger.debug(pretty_xml(xml_response))
 
             refreshed_document = self.get_latest_version()
             return refreshed_document.delete_object()
@@ -513,9 +468,7 @@ class Document(CMISContentObject):
             statement=query(self.uuid),
             cmis_action="query",
         )
-        logger.debug(
-            "get_latest_version: SOAP query request: %s", soap_envelope.toxml()
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         try:
             soap_response = self.request(
@@ -528,11 +481,8 @@ class Document(CMISContentObject):
                 raise DocumentDoesNotExistError(error_string)
             else:
                 raise exc
-        logger.debug(
-            "CMIS_ADAPTER: get_latest_version: SOAP query response: %s", soap_response
-        )
-
         xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
         extracted_data = extract_object_properties_from_xml(xml_response, "query")
         return extract_latest_version(type(self), extracted_data)
 
@@ -578,9 +528,7 @@ class Folder(CMISBaseObject):
             statement=query(str(self.objectId)),
             cmis_action="query",
         )
-        logger.debug(
-            "get_children_folders: SOAP query request: %s", soap_envelope.toxml()
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         try:
             soap_response = self.request(
@@ -592,11 +540,8 @@ class Folder(CMISBaseObject):
                 return []
             else:
                 raise exc
-        logger.debug(
-            "CMIS_ADAPTER: get_children_folders: SOAP query response: %s", soap_response
-        )
-
         xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
 
         extracted_data = extract_object_properties_from_xml(xml_response, "query")
         return [type(self)(folder) for folder in extracted_data]
@@ -612,17 +557,13 @@ class Folder(CMISBaseObject):
             cmis_action="deleteTree",
             continue_on_failure="true",
         )
-        logger.debug(
-            "CMIS_ADAPTER: delete_tree: SOAP deleteTree request: %s",
-            soap_envelope.toxml(),
-        )
+        logger.debug(soap_envelope.toprettyxml())
 
         soap_response = self.request(
             "ObjectService", soap_envelope=soap_envelope.toxml()
         )
-        logger.debug(
-            "CMIS_ADAPTER: delete_tree: SOAP deleteTree response: %s", soap_response
-        )
+        xml_response = extract_xml_from_soap(soap_response)
+        logger.debug(pretty_xml(xml_response))
 
 
 class ZaakTypeFolder(CMISBaseObject):

--- a/drc_cmis/webservice/request.py
+++ b/drc_cmis/webservice/request.py
@@ -1,3 +1,4 @@
+import logging
 from typing import BinaryIO, List, Optional, Tuple, Union
 
 import requests
@@ -16,7 +17,10 @@ from drc_cmis.webservice.utils import (
     extract_root_folder_id_from_xml,
     extract_xml_from_soap,
     make_soap_envelope,
+    pretty_xml,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class SOAPCMISRequest:
@@ -71,11 +75,16 @@ class SOAPCMISRequest:
             soap_envelope = make_soap_envelope(
                 auth=(self.user, self.password), cmis_action="getRepositories"
             )
+
+            logger.debug(soap_envelope.toprettyxml())
+
             soap_response = self.request(
                 "RepositoryService", soap_envelope=soap_envelope.toxml()
             )
 
             xml_response = extract_xml_from_soap(soap_response)
+            logger.debug(pretty_xml(xml_response))
+
             self._main_repo_id = extract_repository_id_from_xml(xml_response)
 
         return self._main_repo_id
@@ -90,11 +99,13 @@ class SOAPCMISRequest:
                 cmis_action="getRepositoryInfo",
                 repository_id=self.main_repo_id,
             )
+            logger.debug(soap_envelope.toprettyxml())
             soap_response = self.request(
                 "RepositoryService", soap_envelope=soap_envelope.toxml()
             )
 
             xml_response = extract_xml_from_soap(soap_response)
+            logger.debug(pretty_xml(xml_response))
             self._root_folder_id = extract_root_folder_id_from_xml(xml_response)
 
         return self._root_folder_id

--- a/drc_cmis/webservice/utils.py
+++ b/drc_cmis/webservice/utils.py
@@ -380,3 +380,8 @@ def extract_xml_from_soap(soap_response, binary=False):
     end_xml = soap_response.find(soap_envelope_end) + len(soap_envelope_end)
 
     return soap_response[begin_xml:end_xml]
+
+
+def pretty_xml(xml_envelope: str) -> str:
+    dom = minidom.parseString(xml_envelope)
+    return dom.toprettyxml()


### PR DESCRIPTION
**Previous behaviour**

The SOAP requests sent to the DMS were logged, but they were not pretty printed. The XML was all on one line, which made it quite difficult to look at.

**New behaviour**
The XML is pretty printed.