### PR TITLE
Functionality to update Gebruiksrechten

### DIFF
--- a/drc_cmis/client.py
+++ b/drc_cmis/client.py
@@ -185,6 +185,29 @@ class CMISClient:
 
         return cmis_doc
 
+    def update_gebruiksrechten(self, drc_uuid: str, data: dict) -> Gebruiksrechten:
+        """Update a gebruiksrechten
+
+        :param drc_uuid: uuid of the gebruiksrechten to update
+        :param data: dict of properties to update
+        :return: Updated gebruiksrechten
+        """
+
+        gebruiksrechten = self.get_content_object(
+            drc_uuid=drc_uuid, object_type="gebruiksrechten"
+        )
+
+        current_properties = gebruiksrechten.properties
+        new_properties = self.gebruiksrechten_type.build_properties(data)
+
+        diff_properties = {
+            key: value
+            for key, value in new_properties.items()
+            if current_properties.get(key) != value
+        }
+
+        return gebruiksrechten.update_properties(diff_properties)
+
     def create_oio(self, data: dict) -> ObjectInformatieObject:
         """Create ObjectInformatieObject which relates a document with a zaak or besluit
 

--- a/drc_cmis/webservice/drc_document.py
+++ b/drc_cmis/webservice/drc_document.py
@@ -188,6 +188,75 @@ class CMISContentObject(CMISBaseObject):
 
         return type(self)(extracted_data)
 
+    def _update_properties(self, properties: dict) -> dict:
+        """
+        Update properties and return the properties of the updated object.
+
+        :param properties: dict, new properties to update
+        :return: dict, properties of the updated object
+        """
+        soap_envelope = make_soap_envelope(
+            auth=(self.user, self.password),
+            repository_id=self.main_repo_id,
+            properties=properties,
+            cmis_action="updateProperties",
+            object_id=self.objectId,
+        )
+        logger.debug(
+            "update_properties: SOAP updateProperties request: %s",
+            soap_envelope.toxml(),
+        )
+
+        soap_response = self.request(
+            "ObjectService",
+            soap_envelope=soap_envelope.toxml(),
+        )
+        logger.debug(
+            "update_properties: SOAP updateProperties response: %s", soap_response
+        )
+
+        xml_response = extract_xml_from_soap(soap_response)
+        extracted_data = extract_object_properties_from_xml(
+            xml_response, "updateProperties"
+        )[0]
+
+        return extracted_data
+
+    def get_content_object(
+        self, object_id: str, object_type: type
+    ) -> "CMISContentObject":
+        """Get a content object with specified objectId
+
+        :param object_id: string, objectId of the content object
+        :param object_type: type, type of the object to return
+        :return: CMISContentObject
+        """
+        soap_envelope = make_soap_envelope(
+            auth=(self.user, self.password),
+            repository_id=self.main_repo_id,
+            object_id=object_id,
+            cmis_action="getObject",
+        )
+        logger.debug(
+            "CMIS_ADAPTER: get_content_object: SOAP getObject request: %s",
+            soap_envelope.toxml(),
+        )
+
+        soap_response = self.request(
+            "ObjectService", soap_envelope=soap_envelope.toxml()
+        )
+        logger.debug(
+            "CMIS_ADAPTER: get_content_object: SOAP getObject response: %s",
+            soap_response,
+        )
+
+        xml_response = extract_xml_from_soap(soap_response)
+        extracted_data = extract_object_properties_from_xml(xml_response, "getObject")[
+            0
+        ]
+
+        return object_type(extracted_data)
+
 
 class Document(CMISContentObject):
     table = "drc:document"
@@ -273,30 +342,7 @@ class Document(CMISContentObject):
         :param object_id: string, objectId of the document
         :return: Document
         """
-        soap_envelope = make_soap_envelope(
-            auth=(self.user, self.password),
-            repository_id=self.main_repo_id,
-            object_id=object_id,
-            cmis_action="getObject",
-        )
-        logger.debug(
-            "CMIS_ADAPTER: get_document: SOAP getObject request: %s",
-            soap_envelope.toxml(),
-        )
-
-        soap_response = self.request(
-            "ObjectService", soap_envelope=soap_envelope.toxml()
-        )
-        logger.debug(
-            "CMIS_ADAPTER: get_document: SOAP getObject response: %s", soap_response
-        )
-
-        xml_response = extract_xml_from_soap(soap_response)
-        extracted_data = extract_object_properties_from_xml(xml_response, "getObject")[
-            0
-        ]
-
-        return type(self)(extracted_data)
+        return self.get_content_object(object_id=object_id, object_type=type(self))
 
     def checkout(self) -> "Document":
         """Checkout a private working copy of the document"""
@@ -393,31 +439,8 @@ class Document(CMISContentObject):
         if content is not None:
             self.set_content_stream(content)
 
-        soap_envelope = make_soap_envelope(
-            auth=(self.user, self.password),
-            repository_id=self.main_repo_id,
-            properties=properties,
-            cmis_action="updateProperties",
-            object_id=self.objectId,
-        )
-        logger.debug(
-            "update_properties: SOAP updateProperties request: %s",
-            soap_envelope.toxml(),
-        )
-
-        soap_response = self.request(
-            "ObjectService",
-            soap_envelope=soap_envelope.toxml(),
-        )
-        logger.debug(
-            "update_properties: SOAP updateProperties response: %s", soap_response
-        )
-
-        xml_response = extract_xml_from_soap(soap_response)
-        extracted_data = extract_object_properties_from_xml(
-            xml_response, "updateProperties"
-        )[0]
-        return self.get_document(extracted_data["properties"]["objectId"]["value"])
+        updated_properties = self._update_properties(properties)
+        return self.get_document(updated_properties["properties"]["objectId"]["value"])
 
     def get_content_stream(self) -> BytesIO:
         soap_envelope = make_soap_envelope(
@@ -542,6 +565,20 @@ class Gebruiksrechten(CMISContentObject):
     name_map = GEBRUIKSRECHTEN_MAP
     type_name = "gebruiksrechten"
     type_class = GebruiksrechtenDoc
+
+    def update_properties(self, properties: dict) -> "Gebruiksrechten":
+        """
+        Update the properties of an existing gebruiksrechten.
+
+        :param properties: dict, the new properties
+        :return: Updated gebruiksrechten
+        """
+        updated_properties = self._update_properties(properties)
+
+        return self.get_content_object(
+            object_id=updated_properties["properties"]["objectId"]["value"],
+            object_type=type(self),
+        )
 
 
 class ObjectInformatieObject(CMISContentObject):

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1533,6 +1533,106 @@ class CMISClientGebruiksrechtenTests(DMSMixin, TestCase):
 
         self.assertEqual(len(gebruiksrechten_copies), 2)
 
+    def test_full_update_gebruiksrechten(self, m):
+        # Creating the document in the temporary folder
+        identification = str(uuid.uuid4())
+        properties = {
+            "bronorganisatie": "159351741",
+            "creatiedatum": timezone.now(),
+            "titel": "detailed summary",
+            "auteur": "test_auteur",
+            "formaat": "txt",
+            "taal": "eng",
+            "bestandsnaam": "dummy.txt",
+            "link": "http://een.link",
+            "beschrijving": "test_beschrijving",
+            "vertrouwelijkheidaanduiding": "openbaar",
+        }
+        content = io.BytesIO(b"some file content")
+
+        document = self.cmis_client.create_document(
+            identification=identification,
+            data=properties,
+            content=content,
+            bronorganisatie="159351741",
+        )
+
+        # Create gebruiksrechten
+        gebruiksrechten_data = {
+            "informatieobject": f"https://testserver/api/v1/documenten/{document.uuid}",
+            "startdatum": "2018-12-24T00:00:00Z",
+            "omschrijving_voorwaarden": "Test voorwaarden",
+        }
+
+        gebruiksrechten = self.cmis_client.create_gebruiksrechten(
+            data=gebruiksrechten_data
+        )
+
+        self.assertEqual("Test voorwaarden", gebruiksrechten.omschrijving_voorwaarden)
+
+        updated_data = {
+            "informatieobject": f"https://testserver/api/v1/documenten/{document.uuid}",
+            "startdatum": "2018-12-24T00:00:00Z",
+            "omschrijving_voorwaarden": "Aangepaste voorwaarden",
+        }
+
+        updated_gebruiksrechten = self.cmis_client.update_gebruiksrechten(
+            drc_uuid=gebruiksrechten.uuid, data=updated_data
+        )
+
+        self.assertEqual(
+            "Aangepaste voorwaarden", updated_gebruiksrechten.omschrijving_voorwaarden
+        )
+
+    def test_partial_update_gebruiksrechten(self, m):
+        # Creating the document in the temporary folder
+        identification = str(uuid.uuid4())
+        properties = {
+            "bronorganisatie": "159351741",
+            "creatiedatum": timezone.now(),
+            "titel": "detailed summary",
+            "auteur": "test_auteur",
+            "formaat": "txt",
+            "taal": "eng",
+            "bestandsnaam": "dummy.txt",
+            "link": "http://een.link",
+            "beschrijving": "test_beschrijving",
+            "vertrouwelijkheidaanduiding": "openbaar",
+        }
+        content = io.BytesIO(b"some file content")
+
+        document = self.cmis_client.create_document(
+            identification=identification,
+            data=properties,
+            content=content,
+            bronorganisatie="159351741",
+        )
+
+        # Create gebruiksrechten
+        gebruiksrechten_data = {
+            "informatieobject": f"https://testserver/api/v1/documenten/{document.uuid}",
+            "startdatum": "2018-12-24T00:00:00Z",
+            "omschrijving_voorwaarden": "Test voorwaarden",
+        }
+
+        gebruiksrechten = self.cmis_client.create_gebruiksrechten(
+            data=gebruiksrechten_data
+        )
+
+        self.assertEqual("Test voorwaarden", gebruiksrechten.omschrijving_voorwaarden)
+
+        updated_data = {
+            "omschrijving_voorwaarden": "Aangepaste voorwaarden",
+        }
+
+        updated_gebruiksrechten = self.cmis_client.update_gebruiksrechten(
+            drc_uuid=gebruiksrechten.uuid, data=updated_data
+        )
+
+        self.assertEqual(
+            "Aangepaste voorwaarden", updated_gebruiksrechten.omschrijving_voorwaarden
+        )
+
 
 @freeze_time("2020-07-27 12:00:00")
 class CMISClientDocumentTests(DMSMixin, TestCase):


### PR DESCRIPTION
Related to issue 811 (https://github.com/open-zaak/open-zaak/issues/811) in open-zaak (PR: https://github.com/open-zaak/open-zaak/pull/812)

The CMIS client has now the ability to update gebruiksrechten in both the Browser and Webservice binding.