### PR TITLE
Fixes #40 - Missing file extension

### DIFF
--- a/drc_cmis/browser/client.py
+++ b/drc_cmis/browser/client.py
@@ -208,7 +208,7 @@ class CMISDRCClient(CMISClient, CMISRequest):
         cmis_doc = Document(json_response)
         content.seek(0)
 
-        return cmis_doc.set_content_stream(content)
+        return cmis_doc.set_content_stream(content, filename=document.bestandsnaam)
 
     def create_content_object(
         self, data: dict, object_type: str, destination_folder: Folder = None
@@ -344,14 +344,14 @@ class CMISDRCClient(CMISClient, CMISRequest):
             data, new=True, identification=identification
         )
 
-        data = create_json_request_body(other_folder, properties)
-        logger.debug("CMIS_ADAPTER: create_document: request data: %s", data)
+        json_data = create_json_request_body(other_folder, properties)
+        logger.debug("CMIS_ADAPTER: create_document: request data: %s", json_data)
 
-        json_response = self.post_request(self.root_folder_url, data=data)
+        json_response = self.post_request(self.root_folder_url, data=json_data)
         logger.debug("CMIS_ADAPTER: create_document: response data: %s", json_response)
         cmis_doc = Document(json_response)
         content.seek(0)
-        return cmis_doc.set_content_stream(content)
+        return cmis_doc.set_content_stream(content, filename=data.get("bestandsnaam"))
 
     def lock_document(self, drc_uuid: str, lock: str):
         """

--- a/drc_cmis/browser/drc_document.py
+++ b/drc_cmis/browser/drc_document.py
@@ -176,11 +176,10 @@ class Document(CMISContentObject):
         logger.debug("CMIS_ADAPTER: checkout: response data: %s", json_response)
         return Document(json_response)
 
-    def update_properties(self, properties: dict, content: Optional[BytesIO] = None):
+    def update_content(self, content: BytesIO, filename: Optional[str] = None):
+        self.set_content_stream(content, filename)
 
-        if content is not None:
-            self.set_content_stream(content)
-
+    def update_properties(self, properties: dict):
         data = {"objectId": self.objectId, "cmisaction": "update"}
         prop_count = 0
         for prop_key, prop_value in properties.items():
@@ -266,13 +265,15 @@ class Document(CMISContentObject):
         logger.debug("CMIS_ADAPTER: checkin: response data: %s", json_response)
         return Document(json_response)
 
-    def set_content_stream(self, content_file):
+    def set_content_stream(self, content_file: BytesIO, filename: Optional[str] = None):
         data = {"objectId": self.objectId, "cmisaction": "setContent"}
 
         mimetype = None
         # need to determine the mime type
-        if not mimetype and hasattr(content_file, "name"):
-            mimetype, _encoding = mimetypes.guess_type(content_file.name)
+        if filename:
+            mimetype, _encoding = mimetypes.guess_type(
+                filename
+            )  # If the extension is not recognised, mimetype is None
 
         if not mimetype:
             mimetype = "application/binary"

--- a/drc_cmis/client.py
+++ b/drc_cmis/client.py
@@ -177,8 +177,12 @@ class CMISClient:
             if current_properties.get(key) != value
         }
 
+        content_filename = data.get("bestandsnaam") or cmis_doc.bestandsnaam
+
         try:
-            cmis_doc.update_properties(diff_properties, content)
+            if content is not None:
+                cmis_doc.update_content(content, content_filename)
+            cmis_doc.update_properties(diff_properties)
         except UpdateConflictException as exc:
             # Node locked!
             raise DocumentConflictException from exc

--- a/drc_cmis/webservice/client.py
+++ b/drc_cmis/webservice/client.py
@@ -276,6 +276,7 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
             properties=cmis_properties,
             cmis_action="createDocument",
             content_id=content_id,
+            content_filename=drc_properties.get("bestandsnaam"),
         )
 
         logger.debug(
@@ -600,6 +601,7 @@ class SOAPCMISClient(CMISClient, SOAPCMISRequest):
             properties=properties,
             cmis_action="createDocument",
             content_id=content_id,
+            content_filename=data.get("bestandsnaam"),
         )
 
         logger.debug(

--- a/drc_cmis/webservice/drc_document.py
+++ b/drc_cmis/webservice/drc_document.py
@@ -386,12 +386,10 @@ class Document(CMISContentObject):
             if document.versionLabel == "pwc":
                 return document
 
-    def update_properties(
-        self, properties: dict, content: Optional[BytesIO] = None
-    ) -> "Document":
-        # Check if the content of the document needs updating
-        if content is not None:
-            self.set_content_stream(content)
+    def update_content(self, content: BytesIO, filename: Optional[str] = None):
+        self.set_content_stream(content, filename)
+
+    def update_properties(self, properties: dict) -> "Document":
 
         soap_envelope = make_soap_envelope(
             auth=(self.user, self.password),
@@ -441,7 +439,7 @@ class Document(CMISContentObject):
         # FIXME find a better way to do this
         return extract_content(soap_response)
 
-    def set_content_stream(self, content: BytesIO):
+    def set_content_stream(self, content: BytesIO, filename: Optional[str] = None):
         content_id = str(uuid.uuid4())
         attachments = [(content_id, content)]
 
@@ -451,6 +449,7 @@ class Document(CMISContentObject):
             object_id=self.objectId,
             cmis_action="setContentStream",
             content_id=content_id,
+            content_filename=filename,
         )
         logger.debug(
             "set_content_stream: SOAP setContentStream request: %s",

--- a/drc_cmis/webservice/request.py
+++ b/drc_cmis/webservice/request.py
@@ -130,20 +130,20 @@ class SOAPCMISRequest:
         # Adding the attachments
         if attachments is not None:
             for attachment in attachments:
+                content_id, content_stream = attachment
                 file_attachment_headers = {
                     "Content-Type": "application/octet-stream",
                     "Content-Transfer-Encoding": "binary",
-                    "Content-ID": f"<{attachment[0]}>",
+                    "Content-ID": f"<{content_id}>",
                 }
 
                 xml_attachment_header = ""
                 for key, value in file_attachment_headers.items():
                     xml_attachment_header += f"{key}: {value}\n"
 
-                attachment_stream = attachment[1]
-                attachment_stream.seek(0)
+                content_stream.seek(0)
                 body += f"{self._boundary}\n{xml_attachment_header}\n".encode("utf-8")
-                body += attachment_stream.read()  # Reads binary
+                body += content_stream.read()  # Reads binary
 
         body += f"{self._boundary}--\n".encode("utf-8")
         soap_response = requests.post(url, data=body, headers=self._headers, files=[])

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -118,6 +118,7 @@ class CMISDocumentTests(DMSMixin, TestCase):
         data = {
             "creatiedatum": datetime.date(2020, 7, 27),
             "titel": "detailed summary",
+            "bestandsnaam": "filename.pdf",
         }
         # Contains non-UTF-8 characters
         content = io.BytesIO(
@@ -133,6 +134,8 @@ class CMISDocumentTests(DMSMixin, TestCase):
         posted_content = document.get_content_stream()
         content.seek(0)
         self.assertEqual(posted_content.read(), content.read())
+
+        self.assertEqual("application/pdf", document.contentStreamMimeType)
 
     @tag("alfresco")
     def test_checkin_document(self):
@@ -217,6 +220,7 @@ class CMISDocumentTests(DMSMixin, TestCase):
             "creatiedatum": datetime.date(2020, 7, 27),
             "titel": "detailed summary",
             "link": "http://a.link",
+            "bestandsnaam": "filename.txt",
         }
         content = io.BytesIO(b"Content before update")
         document = self.cmis_client.create_document(
@@ -231,6 +235,8 @@ class CMISDocumentTests(DMSMixin, TestCase):
         )
         self.assertEqual(document.titel, "detailed summary")
         self.assertEqual(document.link, "http://a.link")
+        self.assertEqual("text/plain", document.contentStreamMimeType)
+
         posted_content = document.get_content_stream()
         content.seek(0)
         self.assertEqual(posted_content.read(), content.read())
@@ -242,19 +248,25 @@ class CMISDocumentTests(DMSMixin, TestCase):
         new_content = io.BytesIO(b"Content after update")
         data = document.build_properties(new_properties, new=False)
         pwc = document.checkout()
-        updated_pwc = pwc.update_properties(properties=data, content=new_content)
+
+        pwc.update_content(new_content, "filename.txt")
+        updated_pwc = pwc.update_properties(properties=data)
+
         updated_document = updated_pwc.checkin("Testing properties update")
+
         self.assertEqual(updated_document.link, "http://an.updated.link")
         self.assertNotEqual(updated_document.versionLabel, document.versionLabel)
         updated_content = updated_document.get_content_stream()
         content.seek(0)
         self.assertEqual(updated_content.read(), b"Content after update")
+        self.assertEqual("text/plain", updated_document.contentStreamMimeType)
 
     def test_get_content_stream(self):
         identification = str(uuid.uuid4())
         data = {
             "creatiedatum": datetime.date(2020, 7, 27),
             "titel": "detailed summary",
+            "bestandsnaam": "filename.txt",
         }
         content = io.BytesIO(b"Some very important content")
         document = self.cmis_client.create_document(
@@ -266,6 +278,7 @@ class CMISDocumentTests(DMSMixin, TestCase):
 
         content_stream = document.get_content_stream()
         self.assertEqual(content_stream.read(), b"Some very important content")
+        self.assertEqual("text/plain", document.contentStreamMimeType)
 
     @skipIf(
         os.getenv("CMIS_BINDING") != "WEBSERVICE",
@@ -276,6 +289,7 @@ class CMISDocumentTests(DMSMixin, TestCase):
         data = {
             "creatiedatum": datetime.date(2020, 7, 27),
             "titel": "detailed summary",
+            "bestandsnaam": "filename.txt",
         }
         content = io.BytesIO(b"Some very important content")
         document = self.cmis_client.create_document(
@@ -287,9 +301,14 @@ class CMISDocumentTests(DMSMixin, TestCase):
 
         all_versions = document.get_all_versions()
         self.assertEqual(len(all_versions), 1)
+        self.assertEqual("text/plain", document.contentStreamMimeType)
 
         content = io.BytesIO(b"Different content")
-        document.set_content_stream(content)
+        document.set_content_stream(content, "filename.txt")
+
+        # Refresh document
+        updated_document = self.cmis_client.get_document(document.uuid)
+        self.assertEqual("text/plain", updated_document.contentStreamMimeType)
 
         all_versions = document.get_all_versions()
         self.assertEqual(len(all_versions), 2)
@@ -309,6 +328,7 @@ class CMISDocumentTests(DMSMixin, TestCase):
         data = {
             "creatiedatum": datetime.date(2020, 7, 27),
             "titel": "detailed summary",
+            "bestandsnaam": "filename.txt",
         }
         content = io.BytesIO(b"Some very important content")
         document = self.cmis_client.create_document(
@@ -323,7 +343,11 @@ class CMISDocumentTests(DMSMixin, TestCase):
         self.assertEqual(len(all_versions), 2)
 
         content = io.BytesIO(b"Different content")
-        document.set_content_stream(content)
+        document.set_content_stream(content, "filename.txt")
+
+        # Refresh document
+        updated_document = self.cmis_client.get_document(document.uuid)
+        self.assertEqual("text/plain", updated_document.contentStreamMimeType)
 
         all_versions = document.get_all_versions()
         self.assertEqual(len(all_versions), 3)
@@ -405,7 +429,7 @@ class CMISDocumentTests(DMSMixin, TestCase):
 
         # Updating the content raises the version by 0.1
         content = io.BytesIO(b"Different content")
-        document.set_content_stream(content)
+        document.set_content_stream(content, "filename.txt")
 
         all_versions = document.get_all_versions()
         self.assertEqual(len(all_versions), 3)
@@ -537,6 +561,23 @@ class CMISDocumentTests(DMSMixin, TestCase):
         self.assertEqual(len(parent_folders), 1)
         # The object is created automatically in a temporary folder name after the current date
         self.assertEqual(parent_folders[0].name, "27")
+
+    def create_document_without_extension(self):
+        properties = {
+            "creatiedatum": datetime.date(2020, 7, 27),
+            "titel": "detailed summary",
+            "bestandsnaam": "filename-without-extension",
+        }
+        content = io.BytesIO(b"some file content")
+
+        document = self.cmis_client.create_document(
+            identification="d1bf9324-46c8-43ae-8bdb-d1a70d682f68",
+            data=properties,
+            content=content,
+            bronorganisatie="159351741",
+        )
+
+        self.assertEqual("application/octet-stream", document.contentStreamMimeType)
 
 
 @freeze_time("2020-07-27 12:00:00")


### PR DESCRIPTION
Fixes #40 

The filename used in the SOAP envelope is now the `bestandsnaam` from openzaak.
The mimetype of the file is also deduced from the filename. 



