### PR TITLE
Speeding up WEBSERVICE binding

### DIFF
--- a/drc_cmis/webservice/request.py
+++ b/drc_cmis/webservice/request.py
@@ -71,10 +71,14 @@ class SOAPCMISRequest:
     @property
     def main_repo_id(self) -> str:
         """Get ID of the CMS main repository"""
+        return self.get_main_repo_id()
+
+    def get_main_repo_id(self, cache: bool = True) -> str:
+        configured_main_repo_id = self.config.main_repo_id
+        if configured_main_repo_id and cache:
+            return configured_main_repo_id
 
         if self._main_repo_id is None:
-            configured_main_repo_id = self.config.main_repo_id
-
             # Retrieving the IDs of all repositories in the CMS
             soap_envelope = make_soap_envelope(
                 auth=(self.user, self.password), cmis_action="getRepositories"

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -46,22 +46,6 @@ class CMISClientTests(DMSMixin, TestCase):
         # In alfresco the repo ID is a UUID
         uuid.UUID(main_repo_id)
 
-    def test_that_main_repo_id_is_checked(self):
-        config = CMISConfig.objects.get()
-        config.main_repo_id = "some-rubbish-id"
-        config.save()
-
-        self.cmis_client._main_repo_id = None
-
-        with self.assertRaises(CmisRepositoryDoesNotExist):
-            try:
-                self.cmis_client.main_repo_id
-            except Exception as e:
-                # Needed or the test clean-up fails!
-                config.main_repo_id = ""
-                config.save()
-                raise e
-
     def test_setting_correct_repo_id(self):
         # Finding what the main repo id is
         self.cmis_client._main_repo_id = None


### PR DESCRIPTION
The parameter `main_repo_id` is used in all requests to a CMIS repository (in Webservice binding).

**Previously**
If the `main_repo_id` was configured through the admin, this value was verified with a call to the CMIS repository.

**Now**
If a value is configured through the admin, it is assumed to be correct.
