### PR TITLE
Issue #52 - Empty identificatie

### DIFF
--- a/drc_cmis/webservice/drc_document.py
+++ b/drc_cmis/webservice/drc_document.py
@@ -335,8 +335,8 @@ class Document(CMISContentObject):
 
             # The identification needs to be set ONLY for newly created documents.
             # identificatie is immutable once the document is created
-            if not props.get(mapper("identificatie"), {}).get("value"):
-                prop_name = mapper("identificatie")
+            prop_name = mapper("identificatie")
+            if not props.get(prop_name, {}).get("value"):
                 prop_type = get_cmis_type(EnkelvoudigInformatieObject, "identificatie")
                 props[prop_name] = {"value": new_uuid, "type": prop_type}
 

--- a/drc_cmis/webservice/drc_document.py
+++ b/drc_cmis/webservice/drc_document.py
@@ -335,7 +335,7 @@ class Document(CMISContentObject):
 
             # The identification needs to be set ONLY for newly created documents.
             # identificatie is immutable once the document is created
-            if not props.get(mapper("identificatie")):
+            if not props.get(mapper("identificatie"), {}).get("value"):
                 prop_name = mapper("identificatie")
                 prop_type = get_cmis_type(EnkelvoudigInformatieObject, "identificatie")
                 props[prop_name] = {"value": new_uuid, "type": prop_type}

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -84,6 +84,7 @@ class CMISDocumentTests(DMSMixin, TestCase):
     )
     @override_settings(CMIS_URL_MAPPING_ENABLED=False)
     def test_build_properties_without_identificatie_webservice(self):
+        # No identificatie
         properties = {
             "bronorganisatie": "159351741",
             "integriteitwaarde": "Something",
@@ -97,6 +98,18 @@ class CMISDocumentTests(DMSMixin, TestCase):
         document = self.cmis_client.create_document(
             data=properties, bronorganisatie="159351741", identification=None
         )
+
+        built_properties = document.build_properties(data=properties)
+
+        self.assertIn("drc:document__uuid", built_properties)
+        self.assertIn("drc:document__identificatie", built_properties)
+        self.assertEqual(
+            built_properties["drc:document__uuid"],
+            built_properties["drc:document__identificatie"],
+        )
+
+        # Empty identificatie
+        properties["identificatie"] = ""
 
         built_properties = document.build_properties(data=properties)
 
@@ -229,6 +242,7 @@ class CMISDocumentTests(DMSMixin, TestCase):
     )
     @override_settings(CMIS_URL_MAPPING_ENABLED=False)
     def test_build_properties_without_identificatie_browser(self):
+        # No identificatie
         properties = {
             "integriteitwaarde": "Something",
             "verwijderd": "false",
@@ -241,6 +255,18 @@ class CMISDocumentTests(DMSMixin, TestCase):
         document = self.cmis_client.create_document(
             data=properties, bronorganisatie="159351741", identification=None
         )
+
+        built_properties = document.build_properties(data=properties)
+
+        self.assertIn("drc:document__uuid", built_properties)
+        self.assertIn("drc:document__identificatie", built_properties)
+        self.assertEqual(
+            built_properties["drc:document__uuid"],
+            built_properties["drc:document__identificatie"],
+        )
+
+        # Empty identificatie
+        properties["identificatie"] = ""
 
         built_properties = document.build_properties(data=properties)
 


### PR DESCRIPTION
Fixes #52 

Bug: If the identificatie was set to an empty string, it was not replaced with the document UUID (in webservice binding). 

