### PR TITLE
Django 3.2 compat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.7', '3.8']
-        django: ['2.2']
+        python: ['3.7', '3.8', '3.9', '3.10']
+        django: ['2.2', '3.2']
         binding: ['BROWSER', 'WEBSERVICE']
         cmisurlmapping: [ 'False', 'True' ]
         exclude:
           - binding: 'BROWSER'
             cmisurlmapping: 'True'
+          - python: '3.10'
+            django: '2.2'
 
     name: Tests (Py${{ matrix.python }}, Django ${{ matrix.django }}, ${{ matrix.binding }}, URL mapping = ${{ matrix.cmisurlmapping }})
 
@@ -35,7 +37,7 @@ jobs:
         run: cd alfresco && docker-compose up -d
 
       - name: Install dependencies
-        run: pip install tox tox-travis codecov
+        run: pip install tox tox-gh-actions codecov
 
       - name: Run tests
         run: |

--- a/drc_cmis/admin.py
+++ b/drc_cmis/admin.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.contrib import admin
 from django.http import JsonResponse
 from django.urls import path
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views import View
 
 from solo.admin import SingletonModelAdmin

--- a/drc_cmis/forms.py
+++ b/drc_cmis/forms.py
@@ -4,7 +4,7 @@ from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.forms import BaseInlineFormSet
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .models import CMISConfig
 

--- a/drc_cmis/models.py
+++ b/drc_cmis/models.py
@@ -2,7 +2,7 @@ import re
 
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 import pytz
 from djchoices import ChoiceItem, DjangoChoices

--- a/drc_cmis/validators.py
+++ b/drc_cmis/validators.py
@@ -1,7 +1,7 @@
 from urllib.parse import urlparse
 
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from drc_cmis.utils import folder
 from drc_cmis.utils.folder import get_folder_structure

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    django < 3.0
+    django>=2.2.0,<4.0
     django-choices
     cmislib-maykin >= 0.7.2.dev0
     django-solo

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,12 +12,17 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Framework :: Django
     Framework :: Django :: 2.2
+    Framework :: Django :: 3.2
     Intended Audience :: Developers
     Operating System :: Unix
     Operating System :: MacOS
     Operating System :: Microsoft :: Windows
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development :: Libraries :: Python Modules
 
@@ -82,7 +87,6 @@ include_trailing_comma = true
 line_length = 88
 multi_line_output = 3
 skip = env,.tox,.history,.eggs
-; skip_glob =
 not_skip = __init__.py
 known_django=django
 known_first_party=drc_cmis
@@ -97,9 +101,6 @@ testpaths = tests
 ; python_paths = .
 
 [pep8]
-max-line-length = 119
-exclude=env,.tox,doc
-
 [flake8]
 max-line-length = 119
 exclude = env,.tox,doc

--- a/tox.ini
+++ b/tox.ini
@@ -1,28 +1,36 @@
 [tox]
 envlist =
-    py{37,38}-django{22,30}-{browser,webservice}
-    py{37,38}-django{22,30}-urlmapping
+    py{37,38,39}-django{22,32}-{browser,webservice}
+    py{37,38,39}-django{22,32}-urlmapping
+    py310-django32-{browser,webservice,urlmapping}
     isort
     black
     flake8
     ; docs
 skip_missing_interpreters = true
 
-[travis:env]
+[gh-actions]
+python =
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
+
+[gh-actions:env]
 DJANGO =
     2.2: django22
-    3.0: django30
+    3.2: django32
 
 CMIS_BINDING =
     BROWSER: browser
     WEBSERVICE: webservice
-    WEBSERVICE: py{37,38}-django{22,30}-urlmapping
+    WEBSERVICE: py{37,38,39}-django{22,32}-urlmapping,py310-django32-urlmapping
 
-IS_URL_MAPPING_ENABLED =
-    True: py{37,38}-django{22,30}-urlmapping
+CMIS_URL_MAPPING_ENABLED =
+    True: py{37,38,39}-django{22,32}-urlmapping,py310-django32-urlmapping
 
 [testenv]
-passenv = CI TRAVIS TRAVIS_* CMIS_BINDING
+passenv = CI CMIS_BINDING
 setenv =
     DJANGO_SETTINGS_MODULE = test_app.settings
     PYTHONPATH = {toxinidir}
@@ -31,14 +39,14 @@ extras =
     coverage
 deps =
   django22: Django~=2.2.0
-  django30: Django~=3.0.0
+  django32: Django~=3.2.0
 commands =
   py.test tests/ \
    --cov=drc_cmis --cov-report xml:reports/coverage-{envname}.xml \
    {posargs}
 
-[testenv:py{37,38}-django{22,30}-urlmapping]
-passenv = CI TRAVIS TRAVIS_* CMIS_BINDING IS_URL_MAPPING_ENABLED
+[testenv:py{37,38,39,310}-django{22,32}-urlmapping]
+passenv = CI CMIS_BINDING CMIS_URL_MAPPING_ENABLED
 setenv =
     DJANGO_SETTINGS_MODULE = test_app.settings
     PYTHONPATH = {toxinidir}
@@ -47,7 +55,7 @@ extras =
     coverage
 deps =
   django22: Django~=2.2.0
-  django30: Django~=3.0.0
+  django32: Django~=3.2.0
 commands =
   py.test tests/ \
    --cov=drc_cmis --cov-report xml:reports/coverage-{envname}.xml \
@@ -76,5 +84,5 @@ extras = docs
 commands=
     py.test check_sphinx.py -v \
     --junitxml=../reports/junit-{envname}.xml \
-    --tb=line \
+    --tb=auto \
     {posargs}


### PR DESCRIPTION
Fixes #63

Note: currently the tests in the Django 3.2 matrix are running with Django 2.2 because of the deps by vng-api-common 1.6.4 which downgrades Django again.

**Tasks**

- [x] Publish new vng-api-common version