### PR TITLE
Fix Document.bestandsomvang=None not being writable

### DIFF
--- a/drc_cmis/client.py
+++ b/drc_cmis/client.py
@@ -190,8 +190,10 @@ class CMISClient:
             # Content can be empty in case of large file uploads, because the file is
             # uploaded using `BestandsDelen`
             # https://github.com/VNG-Realisatie/gemma-zaken/blob/master/docs/_content/standaard/documenten/index.md#opslaan-van-bestanden
-            # cmis_doc.update_content(content or BytesIO(b""), content_filename)
-            if content is not None:
+            should_clear_file = (
+                "bestandsomvang" in data and data["bestandsomvang"] is None
+            )
+            if content is not None or should_clear_file:
                 cmis_doc.update_content(content or BytesIO(b""), content_filename)
 
             if diff_properties:

--- a/drc_cmis/webservice/drc_document.py
+++ b/drc_cmis/webservice/drc_document.py
@@ -314,6 +314,9 @@ class Document(CMISContentObject):
             elif key == "indicatie_gebruiksrecht":
                 prop_type = get_cmis_type(EnkelvoudigInformatieObject, key)
                 props[prop_name] = {"value": "", "type": prop_type}
+            elif key == "bestandsomvang" and value is None:
+                prop_type = get_cmis_type(EnkelvoudigInformatieObject, key)
+                props[prop_name] = {"value": None, "type": prop_type}
 
         # For documents that are not new, the uuid shouldn't be written
         props.pop(mapper("uuid"), None)

--- a/drc_cmis/webservice/utils.py
+++ b/drc_cmis/webservice/utils.py
@@ -281,10 +281,12 @@ def make_soap_envelope(
             property_element = xml_doc.createElement(f"ns1:{prop_dict['type']}")
             property_element.setAttribute("propertyDefinitionId", prop_name)
 
-            value_element = xml_doc.createElement("ns1:value")
-            value_text = xml_doc.createTextNode(prop_dict["value"])
-            value_element.appendChild(value_text)
-            property_element.appendChild(value_element)
+            value = prop_dict["value"]
+            if value is not None:
+                value_element = xml_doc.createElement("ns1:value")
+                value_text = xml_doc.createTextNode(value)
+                value_element.appendChild(value_text)
+                property_element.appendChild(value_element)
 
             properties_element.appendChild(property_element)
         action_element.appendChild(properties_element)

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -2070,6 +2070,45 @@ class CMISClientDocumentTests(DMSMixin, TestCase):
                 drc_uuid=document.uuid, lock=str(uuid.uuid4()), data=new_properties
             )
 
+    def test_update_document_to_null_bestandsomvang(self):
+        identification = str(uuid.uuid4())
+        properties = {
+            "creatiedatum": timezone.now(),
+            "titel": "detailed summary",
+            "auteur": "test_auteur",
+            "formaat": "txt",
+            "taal": "eng",
+            "bestandsnaam": "dummy.txt",
+            "link": "https://drc.utrechtproeftuin.nl/api/v1/enkelvoudiginformatieobjecten/d06f86e0-1c3a-49cf-b5cd-01c079cf8147/download",
+            "beschrijving": "test_beschrijving",
+            "vertrouwelijkheidaanduiding": "openbaar",
+            "uuid": str(uuid.uuid4()),
+        }
+        content = io.BytesIO(b"Content before update")
+
+        document = self.cmis_client.create_document(
+            identification=identification,
+            data=properties,
+            content=content,
+            bronorganisatie="159351741",
+        )
+
+        new_properties = {"bestandsomvang": None}
+        new_content = None
+
+        lock = str(uuid.uuid4())
+        self.cmis_client.lock_document(drc_uuid=document.uuid, lock=lock)
+        self.cmis_client.update_document(
+            drc_uuid=document.uuid, lock=lock, data=new_properties, content=new_content
+        )
+        updated_doc = self.cmis_client.unlock_document(
+            drc_uuid=document.uuid, lock=lock
+        )
+
+        self.assertIsNone(updated_doc.bestandsomvang)
+        posted_content = updated_doc.get_content_stream()
+        self.assertEqual(posted_content.read(), b"")
+
     def test_copy_document(self):
         # Create first document
         identification = str(uuid.uuid4())


### PR DESCRIPTION
Before this patch, None values were just skipped. This made it impossible to change
the bestandsomvang from non-null value to null value.